### PR TITLE
Create worker_ci.yaml

### DIFF
--- a/.github/workflows/worker_ci.yaml
+++ b/.github/workflows/worker_ci.yaml
@@ -1,0 +1,48 @@
+name: Worker CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  worker-tests:
+    runs-on: ubuntu-latest
+
+    env:
+      DATABASE_URL: postgresql://postgres:password123@localhost:5433/mlsec_test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Start test database via Docker Compose
+        run: docker compose up -d postgres-test
+
+      - name: Wait for test database readiness
+        run: |
+          for i in {1..30}; do
+            if docker exec test-postgres-db pg_isready -U postgres -d mlsec_test; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Test database did not become ready in time."
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Worker test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r services/worker/requirements.txt
+
+      - name: Run Worker pytest suite
+        working-directory: services/worker
+        run: pytest -v
+
+      - name: Stop Docker Compose services
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
Obviously this has no functional changes to the code, but I needed the tests from your branch to test to see if the workflow set up the environment correctly. CodeQL probably will get made at this too since its basically the same as the other CI. We can do security hardening for this later. 
