### PR TITLE
Admin localhost page backend logic 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
+# docker tmp
+.docker-tmp/
+
 # jetbrains setting folder
 .idea/
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,6 +91,7 @@ services:
       DATABASE_URL: postgresql://postgres:password123@postgres:5432/mlsec
       CELERY_BROKER_URL: amqp://mlsec:mlsec@rabbitmq:5672//
       REDIS_URL: redis://redis:6379/0
+      ADMIN_ALLOWED_HOSTS: '["172.20.0.1"]' # TODO: make this a YAML config thing
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,7 +153,8 @@ services:
       dockerfile: Dockerfile
     container_name: mlsec-frontend
     environment:
-      PUBLIC_API_URL: http://localhost:8000
+      PUBLIC_API_URL: http://api:8000
+      API_PROXY_TARGET: http://api:8000
     volumes:
       - ./services/frontend:/app
       - /app/node_modules

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
       DATABASE_URL: postgresql://postgres:password123@postgres:5432/mlsec
       CELERY_BROKER_URL: amqp://mlsec:mlsec@rabbitmq:5672//
       REDIS_URL: redis://redis:6379/0
-      ADMIN_ALLOWED_HOSTS: '["172.21.0.1"]' # Docker bridge gateway for localhost SSH tunnel access
+      ADMIN_ALLOWED_HOSTS: '["172.22.0.1"]' # Docker bridge gateway for localhost SSH tunnel access
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
       DATABASE_URL: postgresql://postgres:password123@postgres:5432/mlsec
       CELERY_BROKER_URL: amqp://mlsec:mlsec@rabbitmq:5672//
       REDIS_URL: redis://redis:6379/0
-      ADMIN_ALLOWED_HOSTS: '["172.20.0.1"]' # TODO: make this a YAML config thing
+      ADMIN_ALLOWED_HOSTS: '["172.21.0.1"]' # Docker bridge gateway for localhost SSH tunnel access
     ports:
       - "8000:8000"
     volumes:

--- a/services/api/core/admin.py
+++ b/services/api/core/admin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ipaddress import ip_address
+from ipaddress import ip_address, ip_network
 from typing import Iterable
 
 from fastapi import Depends, HTTPException, Request, status
@@ -47,6 +47,30 @@ def _is_from_trusted_proxy(host: str | None, trusted_proxy_hosts: Iterable[str])
     return any(_hosts_match(host, trusted) for trusted in trusted_proxy_hosts)
 
 
+def _is_in_allowed_hosts(host: str | None, allowed_hosts: Iterable[str]) -> bool:
+    if host is None:
+        return False
+    return any(_hosts_match(host, allowed) for allowed in allowed_hosts)
+
+
+def _is_in_allowed_networks(host: str | None, allowed_networks: Iterable[str]) -> bool:
+    if host is None:
+        return False
+    normalized = host.strip().lower()
+    try:
+        host_ip = ip_address(normalized)
+    except ValueError:
+        return False
+
+    for network in allowed_networks:
+        try:
+            if host_ip in ip_network(network, strict=False):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 def _get_effective_client_host(request: Request) -> str | None:
     settings = get_settings()
     direct_host = request.client.host if request.client is not None else None
@@ -70,6 +94,10 @@ def require_localhost_request(request: Request) -> None:
 
     client_host = _get_effective_client_host(request)
     if _is_loopback_host(client_host):
+        return
+    if _is_in_allowed_hosts(client_host, settings.admin_allowed_hosts):
+        return
+    if _is_in_allowed_networks(client_host, settings.admin_allowed_networks):
         return
 
     raise HTTPException(

--- a/services/api/core/admin.py
+++ b/services/api/core/admin.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from ipaddress import ip_address
+from typing import Iterable
+
+from fastapi import Depends, HTTPException, Request, status
+
+from core.auth import AuthenticatedUser, get_authenticated_user
+from core.settings import get_settings
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    if host is None:
+        return False
+
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+
+    try:
+        parsed = ip_address(normalized)
+    except ValueError:
+        return False
+
+    if parsed.is_loopback:
+        return True
+
+    ipv4_mapped = getattr(parsed, "ipv4_mapped", None)
+    return bool(ipv4_mapped and ipv4_mapped.is_loopback)
+
+
+def _hosts_match(left: str, right: str) -> bool:
+    left_normalized = left.strip().lower()
+    right_normalized = right.strip().lower()
+    if left_normalized == right_normalized:
+        return True
+
+    try:
+        return ip_address(left_normalized) == ip_address(right_normalized)
+    except ValueError:
+        return False
+
+
+def _is_from_trusted_proxy(host: str | None, trusted_proxy_hosts: Iterable[str]) -> bool:
+    if host is None:
+        return False
+    return any(_hosts_match(host, trusted) for trusted in trusted_proxy_hosts)
+
+
+def _get_effective_client_host(request: Request) -> str | None:
+    settings = get_settings()
+    direct_host = request.client.host if request.client is not None else None
+    if not _is_from_trusted_proxy(direct_host, settings.admin_trusted_proxy_hosts):
+        return direct_host
+
+    forwarded_for = request.headers.get(settings.admin_forwarded_for_header)
+    if not forwarded_for:
+        return direct_host
+
+    first_forwarded_host = forwarded_for.split(",")[0].strip()
+    if first_forwarded_host:
+        return first_forwarded_host
+    return direct_host
+
+
+def require_localhost_request(request: Request) -> None:
+    settings = get_settings()
+    if not settings.admin_localhost_only:
+        return
+
+    client_host = _get_effective_client_host(request)
+    if _is_loopback_host(client_host):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Admin endpoints are only available from localhost",
+    )
+
+
+def require_admin_user(
+    current_user: AuthenticatedUser = Depends(get_authenticated_user),
+) -> AuthenticatedUser:
+    if current_user.is_admin:
+        return current_user
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Admin privileges required",
+    )

--- a/services/api/core/admin.py
+++ b/services/api/core/admin.py
@@ -16,6 +16,7 @@ from core.settings import get_settings
 
 
 def _is_loopback_host(host: str | None) -> bool:
+    """Return True when the host resolves to a loopback address."""
     if host is None:
         return False
 
@@ -36,6 +37,7 @@ def _is_loopback_host(host: str | None) -> bool:
 
 
 def _hosts_match(left: str, right: str) -> bool:
+    """Normalize and compare hostnames or IP literals."""
     left_normalized = left.strip().lower()
     right_normalized = right.strip().lower()
     if left_normalized == right_normalized:
@@ -48,18 +50,21 @@ def _hosts_match(left: str, right: str) -> bool:
 
 
 def _is_from_trusted_proxy(host: str | None, trusted_proxy_hosts: Iterable[str]) -> bool:
+    """Return True when the direct client matches a configured proxy host."""
     if host is None:
         return False
     return any(_hosts_match(host, trusted) for trusted in trusted_proxy_hosts)
 
 
 def _is_in_allowed_hosts(host: str | None, allowed_hosts: Iterable[str]) -> bool:
+    """Return True when the host matches a configured allowlist entry."""
     if host is None:
         return False
     return any(_hosts_match(host, allowed) for allowed in allowed_hosts)
 
 
 def _is_in_allowed_networks(host: str | None, allowed_networks: Iterable[str]) -> bool:
+    """Return True when the host belongs to an allowed CIDR range."""
     if host is None:
         return False
     normalized = host.strip().lower()
@@ -78,8 +83,10 @@ def _is_in_allowed_networks(host: str | None, allowed_networks: Iterable[str]) -
 
 
 def _get_effective_client_host(request: Request) -> str | None:
+    """Derive the true client host, honoring trusted proxy headers."""
     settings = get_settings()
     direct_host = request.client.host if request.client is not None else None
+    # Only trust X-Forwarded-For when the immediate peer is a known proxy.
     if not _is_from_trusted_proxy(direct_host, settings.admin_trusted_proxy_hosts):
         return direct_host
 
@@ -94,6 +101,7 @@ def _get_effective_client_host(request: Request) -> str | None:
 
 
 def require_localhost_request(request: Request) -> None:
+    """Enforce localhost-only admin access unless allowlists override it."""
     settings = get_settings()
     if not settings.admin_localhost_only:
         return
@@ -115,6 +123,7 @@ def require_localhost_request(request: Request) -> None:
 def require_admin_user(
     current_user: AuthenticatedUser = Depends(get_authenticated_user),
 ) -> AuthenticatedUser:
+    """Require that the authenticated user has admin privileges."""
     if current_user.is_admin:
         return current_user
 
@@ -125,6 +134,7 @@ def require_admin_user(
 
 
 def _hash_token(token: str) -> str:
+    """Hash a token for storage and comparison."""
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 

--- a/services/api/core/admin.py
+++ b/services/api/core/admin.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 from ipaddress import ip_address, ip_network
 from typing import Iterable
+from urllib.parse import urlparse
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
 
 from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from core.auth import AuthenticatedUser, get_authenticated_user
 from core.settings import get_settings
@@ -115,4 +121,146 @@ def require_admin_user(
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail="Admin privileges required",
+    )
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def require_admin_origin(request: Request, *, require_present: bool = True) -> None:
+    """Ensure Origin/Referer points to localhost (and is present if required)."""
+    origin = request.headers.get("origin")
+    referer = request.headers.get("referer")
+
+    def _origin_host(value: str) -> str | None:
+        try:
+            parsed = urlparse(value)
+            return parsed.hostname
+        except Exception:
+            return None
+
+    if require_present and not origin and not referer:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin actions require a localhost browser origin",
+        )
+
+    if origin:
+        origin_host = _origin_host(origin)
+        if not _is_loopback_host(origin_host):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin actions require localhost origin",
+            )
+
+    if referer:
+        referer_host = _origin_host(referer)
+        if not _is_loopback_host(referer_host):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin actions require localhost origin",
+            )
+
+
+def issue_admin_action_token(
+    db: Session,
+    *,
+    session_id: str,
+) -> tuple[str, datetime]:
+    """Generate and persist a short-lived admin action token."""
+    settings = get_settings()
+    token = secrets.token_urlsafe(32)
+    token_hash = _hash_token(token)
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        minutes=settings.admin_action_token_ttl_minutes
+    )
+
+    db.execute(
+        text(
+            """
+            DELETE FROM admin_action_tokens
+            WHERE session_id = :session_id
+            """
+        ),
+        {"session_id": session_id},
+    )
+
+    db.execute(
+        text(
+            """
+            INSERT INTO admin_action_tokens (session_id, token_hash, expires_at)
+            VALUES (:session_id, :token_hash, :expires_at)
+            """
+        ),
+        {
+            "session_id": session_id,
+            "token_hash": token_hash,
+            "expires_at": expires_at,
+        },
+    )
+
+    db.commit()
+    return token, expires_at
+
+
+def require_admin_action_token(
+    request: Request,
+    *,
+    db: Session,
+    session_id: str,
+) -> str:
+    """Validate the admin action token against the session."""
+    token = request.headers.get("x-admin-action")
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin action token required",
+        )
+
+    token_hash = _hash_token(token)
+    row = db.execute(
+        text(
+            """
+            SELECT expires_at
+            FROM admin_action_tokens
+            WHERE session_id = :session_id
+              AND token_hash = :token_hash
+            """
+        ),
+        {"session_id": session_id, "token_hash": token_hash},
+    ).fetchone()
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid admin action token",
+        )
+
+    expires_at = row[0]
+    if expires_at and expires_at <= datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin action token expired",
+        )
+    return token
+
+
+def consume_admin_action_token(
+    db: Session,
+    *,
+    session_id: str,
+    token: str,
+) -> None:
+    """Consume an admin action token after use."""
+    token_hash = _hash_token(token)
+    db.execute(
+        text(
+            """
+            DELETE FROM admin_action_tokens
+            WHERE session_id = :session_id
+              AND token_hash = :token_hash
+            """
+        ),
+        {"session_id": session_id, "token_hash": token_hash},
     )

--- a/services/api/core/audit.py
+++ b/services/api/core/audit.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from core.database import get_engine
+
+logger = logging.getLogger(__name__)
+
+
+def log_audit_event(
+    *,
+    event_type: str,
+    user_id: UUID | None = None,
+    email: str | None = None,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
+    success: bool | None = None,
+    message: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Persist a structured audit log event.
+
+    This uses a standalone connection so audit logging does not interfere
+    with request transactions.
+    """
+    try:
+        payload = json.dumps(metadata) if metadata is not None else None
+        with get_engine().begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO audit_logs (
+                        event_type,
+                        user_id,
+                        email,
+                        ip_address,
+                        user_agent,
+                        success,
+                        message,
+                        metadata
+                    )
+                    VALUES (
+                        :event_type,
+                        :user_id,
+                        :email,
+                        :ip_address,
+                        :user_agent,
+                        :success,
+                        :message,
+                        CAST(:metadata AS jsonb)
+                    )
+                    """
+                ),
+                {
+                    "event_type": event_type,
+                    "user_id": str(user_id) if user_id else None,
+                    "email": email,
+                    "ip_address": ip_address,
+                    "user_agent": user_agent,
+                    "success": success,
+                    "message": message,
+                    "metadata": payload,
+                },
+            )
+    except Exception as exc:
+        logger.warning("Failed to write audit log: %s", exc)

--- a/services/api/core/auth.py
+++ b/services/api/core/auth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
@@ -21,6 +22,7 @@ from core.database import get_db
 from core.settings import get_settings
 
 SESSION_COOKIE_ALIAS = get_settings().auth_session_cookie_name
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -140,6 +142,7 @@ def create_session(
 
     if commit:
         db.commit()
+    logger.info("Created session %s for user %s", row["id"], user_id)
 
     return SessionToken(
         session_id=row["id"],
@@ -169,6 +172,7 @@ def revoke_session_by_id(db: Session, *, session_id: UUID, commit: bool = True) 
     )
     if commit:
         db.commit()
+    logger.info("Revoked session %s", session_id)
 
 
 def _maybe_renew_session(

--- a/services/api/core/database.py
+++ b/services/api/core/database.py
@@ -5,6 +5,7 @@ dependency injection and health checks.
 """
 
 import os
+import logging
 from functools import lru_cache
 
 from sqlalchemy import create_engine, text  # type: ignore
@@ -15,6 +16,7 @@ from core.settings import get_settings
 
 # TODO: Change this to .env for resolving password, port, etc.
 DEFAULT_DATABASE_URL = "postgresql://postgres:password123@postgres:5432/mlsec"
+logger = logging.getLogger(__name__)
 
 
 def get_database_url() -> str:
@@ -26,6 +28,7 @@ def get_database_url() -> str:
 @lru_cache(maxsize=1)
 def get_engine() -> Engine:
     """Create (and cache) the SQLAlchemy Engine."""
+    logger.info("Creating database engine")
     return create_engine(get_database_url(), pool_pre_ping=True)
 
 
@@ -49,5 +52,6 @@ def ping_db() -> bool:
         with get_engine().connect() as conn:
             conn.execute(text("SELECT 1"))
         return True
-    except Exception:
+    except Exception as exc:
+        logger.warning("Database ping failed", exc_info=exc)
         return False

--- a/services/api/core/settings.py
+++ b/services/api/core/settings.py
@@ -45,6 +45,10 @@ class Settings(BaseSettings):
     auth_session_cookie_path: str = "/"
     auth_session_cookie_domain: str | None = None
 
+    admin_localhost_only: bool = True
+    admin_trusted_proxy_hosts: list[str] = ["127.0.0.1", "::1"]
+    admin_forwarded_for_header: str = "x-forwarded-for"
+
     cors_allow_origins: list[str] = [
         "http://localhost:4321",
         "http://127.0.0.1:4321",

--- a/services/api/core/settings.py
+++ b/services/api/core/settings.py
@@ -55,6 +55,7 @@ class Settings(BaseSettings):
         "http://localhost:4321",
         "http://127.0.0.1:4321",
     ]
+    cors_allow_origin_regex: str | None = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
     cors_allow_methods: list[str] = ["*"]
     cors_allow_headers: list[str] = ["*"]
     cors_allow_credentials: bool = True

--- a/services/api/core/settings.py
+++ b/services/api/core/settings.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     admin_forwarded_for_header: str = "x-forwarded-for"
     admin_allowed_hosts: list[str] = []
     admin_allowed_networks: list[str] = []
+    admin_action_token_ttl_minutes: int = 15
 
     cors_allow_origins: list[str] = [
         "http://localhost:4321",

--- a/services/api/core/settings.py
+++ b/services/api/core/settings.py
@@ -48,6 +48,8 @@ class Settings(BaseSettings):
     admin_localhost_only: bool = True
     admin_trusted_proxy_hosts: list[str] = ["127.0.0.1", "::1"]
     admin_forwarded_for_header: str = "x-forwarded-for"
+    admin_allowed_hosts: list[str] = []
+    admin_allowed_networks: list[str] = []
 
     cors_allow_origins: list[str] = [
         "http://localhost:4321",

--- a/services/api/core/submission_control.py
+++ b/services/api/core/submission_control.py
@@ -11,10 +11,12 @@ from sqlalchemy.orm import Session
 
 
 def _utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
     return datetime.now(timezone.utc)
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
+    """Normalize datetimes to UTC (assumes naive values are UTC)."""
     if value is None:
         return None
     if value.tzinfo is None:
@@ -24,12 +26,14 @@ def _as_utc(value: datetime | None) -> datetime | None:
 
 @dataclass(frozen=True)
 class SubmissionControl:
+    """Snapshot of the submission window configuration."""
     manual_closed: bool
     close_at: datetime | None
     updated_at: datetime | None
     updated_by: str | None
 
     def is_closed(self, *, now: datetime | None = None) -> bool:
+        """Return True when submissions should be treated as closed."""
         current = now or _utcnow()
         if self.manual_closed:
             return True
@@ -39,6 +43,7 @@ class SubmissionControl:
 
 
 def get_submission_control(db: Session) -> SubmissionControl:
+    """Load the current submission control state (single-row table)."""
     row = (
         db.execute(
             text(
@@ -54,6 +59,7 @@ def get_submission_control(db: Session) -> SubmissionControl:
     )
 
     if row is None:
+        # Ensure the control row exists so downstream code always has a baseline.
         db.execute(
             text(
                 """
@@ -85,6 +91,7 @@ def set_manual_closed(
     closed: bool,
     updated_by: str | None,
 ) -> SubmissionControl:
+    """Toggle the manual close flag and return the updated control state."""
     row = (
         db.execute(
             text(
@@ -122,6 +129,7 @@ def set_close_at(
     close_at: datetime | None,
     updated_by: str | None,
 ) -> SubmissionControl:
+    """Set or clear the scheduled close time and return the updated control state."""
     close_at_utc = _as_utc(close_at)
     row = (
         db.execute(
@@ -155,6 +163,7 @@ def set_close_at(
 
 
 def ensure_submissions_open(db: Session) -> None:
+    """Raise 403 when submissions are closed by admin or deadline."""
     control = get_submission_control(db)
     now = _utcnow()
     if control.manual_closed:

--- a/services/api/core/submission_control.py
+++ b/services/api/core/submission_control.py
@@ -1,0 +1,169 @@
+"""Helpers for managing submission windows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class SubmissionControl:
+    manual_closed: bool
+    close_at: datetime | None
+    updated_at: datetime | None
+    updated_by: str | None
+
+    def is_closed(self, *, now: datetime | None = None) -> bool:
+        current = now or _utcnow()
+        if self.manual_closed:
+            return True
+        if self.close_at and self.close_at <= current:
+            return True
+        return False
+
+
+def get_submission_control(db: Session) -> SubmissionControl:
+    row = (
+        db.execute(
+            text(
+                """
+                SELECT manual_closed, close_at, updated_at, updated_by
+                FROM submission_control
+                WHERE id = 1
+                """
+            )
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    if row is None:
+        db.execute(
+            text(
+                """
+                INSERT INTO submission_control (id)
+                VALUES (1)
+                ON CONFLICT (id) DO NOTHING
+                """
+            )
+        )
+        db.commit()
+        return SubmissionControl(
+            manual_closed=False,
+            close_at=None,
+            updated_at=None,
+            updated_by=None,
+        )
+
+    return SubmissionControl(
+        manual_closed=bool(row["manual_closed"]),
+        close_at=_as_utc(row["close_at"]),
+        updated_at=_as_utc(row["updated_at"]),
+        updated_by=str(row["updated_by"]) if row["updated_by"] else None,
+    )
+
+
+def set_manual_closed(
+    db: Session,
+    *,
+    closed: bool,
+    updated_by: str | None,
+) -> SubmissionControl:
+    row = (
+        db.execute(
+            text(
+                """
+                INSERT INTO submission_control (id, manual_closed, updated_at, updated_by)
+                VALUES (1, :manual_closed, :updated_at, :updated_by)
+                ON CONFLICT (id) DO UPDATE
+                SET manual_closed = EXCLUDED.manual_closed,
+                    updated_at = EXCLUDED.updated_at,
+                    updated_by = EXCLUDED.updated_by
+                RETURNING manual_closed, close_at, updated_at, updated_by
+                """
+            ),
+            {
+                "manual_closed": closed,
+                "updated_at": _utcnow(),
+                "updated_by": updated_by,
+            },
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    return SubmissionControl(
+        manual_closed=bool(row["manual_closed"]),
+        close_at=_as_utc(row["close_at"]),
+        updated_at=_as_utc(row["updated_at"]),
+        updated_by=str(row["updated_by"]) if row["updated_by"] else None,
+    )
+
+
+def set_close_at(
+    db: Session,
+    *,
+    close_at: datetime | None,
+    updated_by: str | None,
+) -> SubmissionControl:
+    close_at_utc = _as_utc(close_at)
+    row = (
+        db.execute(
+            text(
+                """
+                INSERT INTO submission_control (id, close_at, updated_at, updated_by)
+                VALUES (1, :close_at, :updated_at, :updated_by)
+                ON CONFLICT (id) DO UPDATE
+                SET close_at = EXCLUDED.close_at,
+                    updated_at = EXCLUDED.updated_at,
+                    updated_by = EXCLUDED.updated_by
+                RETURNING manual_closed, close_at, updated_at, updated_by
+                """
+            ),
+            {
+                "close_at": close_at_utc,
+                "updated_at": _utcnow(),
+                "updated_by": updated_by,
+            },
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    return SubmissionControl(
+        manual_closed=bool(row["manual_closed"]),
+        close_at=_as_utc(row["close_at"]),
+        updated_at=_as_utc(row["updated_at"]),
+        updated_by=str(row["updated_by"]) if row["updated_by"] else None,
+    )
+
+
+def ensure_submissions_open(db: Session) -> None:
+    control = get_submission_control(db)
+    now = _utcnow()
+    if control.manual_closed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Submissions are closed by an administrator",
+        )
+    if control.close_at and control.close_at <= now:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Submissions are closed (deadline passed)",
+        )

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from core.settings import get_settings
+from routers.admin import router as admin_router
 from routers.auth import router as auth_router
 from routers.health import router as health_router
 from routers.leaderboard import (
@@ -81,6 +82,7 @@ def create_app() -> FastAPI:
     app.include_router(queue_router)
     app.include_router(submissions_router, prefix="/api")
     app.include_router(leaderboard_router, prefix="/api")
+    app.include_router(admin_router)
     return app
 
 

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -72,6 +72,7 @@ def create_app() -> FastAPI:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_allow_origins,
+        allow_origin_regex=settings.cors_allow_origin_regex,
         allow_credentials=settings.cors_allow_credentials,
         allow_methods=settings.cors_allow_methods,
         allow_headers=settings.cors_allow_headers,

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -33,7 +33,9 @@ from schemas.admin import (
     AdminRevokeSessionsResponse,
     AdminSetAdminRequest,
     AdminSystemCounts,
+    AdminUserRecord,
     AdminUserActionResponse,
+    AdminUsersResponse,
 )
 
 router = APIRouter(
@@ -84,6 +86,69 @@ def get_overview(
         environment=get_settings().env,
         counts=AdminSystemCounts(**counts_row),
     )
+
+
+@router.get("/users", response_model=AdminUsersResponse)
+def get_users(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=200, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    search: str | None = Query(default=None),
+    include_disabled: bool = Query(default=True),
+) -> AdminUsersResponse:
+    search_like = f"%{search}%" if search else None
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    u.id,
+                    u.email,
+                    u.username,
+                    u.is_admin,
+                    u.created_at,
+                    u.disabled_at,
+                    last_seen.last_seen_at,
+                    COALESCE(active_sessions.active_count, 0) AS active_sessions
+                FROM users u
+                LEFT JOIN LATERAL (
+                    SELECT COALESCE(us.last_seen_at, us.created_at) AS last_seen_at
+                    FROM user_sessions us
+                    WHERE us.user_id = u.id
+                      AND us.revoked_at IS NULL
+                      AND us.expires_at > NOW()
+                    ORDER BY COALESCE(us.last_seen_at, us.created_at) DESC
+                    LIMIT 1
+                ) last_seen ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT COUNT(*) AS active_count
+                    FROM user_sessions us2
+                    WHERE us2.user_id = u.id
+                      AND us2.revoked_at IS NULL
+                      AND us2.expires_at > NOW()
+                ) active_sessions ON TRUE
+                WHERE (:search IS NULL OR u.email ILIKE :search_like OR u.username ILIKE :search_like)
+                  AND (:include_disabled OR u.disabled_at IS NULL)
+                ORDER BY u.created_at DESC
+                LIMIT :limit
+                OFFSET :offset
+                """
+            ),
+            {
+                "search": search,
+                "search_like": search_like,
+                "include_disabled": include_disabled,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminUserRecord(**row) for row in rows]
+    return AdminUsersResponse(count=len(items), items=items)
 
 
 @router.get("/logs/jobs", response_model=AdminJobLogsResponse)

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from core.admin import require_admin_user, require_localhost_request
+from core.auth import AuthenticatedUser
+from core.database import get_db
+from core.settings import get_settings
+from schemas.admin import (
+    AdminActiveSessionRecord,
+    AdminActiveSessionsResponse,
+    AdminEvaluationLogRecord,
+    AdminEvaluationLogsResponse,
+    AdminJobLogRecord,
+    AdminJobLogsResponse,
+    AdminOverviewResponse,
+    AdminSystemCounts,
+)
+
+router = APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    dependencies=[Depends(require_localhost_request)],
+)
+
+
+@router.get("/overview", response_model=AdminOverviewResponse)
+def get_overview(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminOverviewResponse:
+    counts_row = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM users) AS users_total,
+                    (SELECT COUNT(*) FROM users WHERE disabled_at IS NULL) AS users_active,
+                    (
+                        SELECT COUNT(*)
+                        FROM user_sessions
+                        WHERE revoked_at IS NULL
+                          AND expires_at > NOW()
+                    ) AS sessions_active,
+                    (SELECT COUNT(*) FROM submissions WHERE deleted_at IS NULL) AS submissions_total,
+                    (SELECT COUNT(*) FROM evaluation_runs) AS evaluation_runs_total,
+                    (SELECT COUNT(*) FROM jobs WHERE status = 'queued') AS jobs_queued,
+                    (SELECT COUNT(*) FROM jobs WHERE status = 'running') AS jobs_running,
+                    (SELECT COUNT(*) FROM jobs WHERE status = 'failed') AS jobs_failed
+                """
+            )
+        )
+        .mappings()
+        .one()
+    )
+
+    return AdminOverviewResponse(
+        generated_at=datetime.now(timezone.utc),
+        environment=get_settings().env,
+        counts=AdminSystemCounts(**counts_row),
+    )
+
+
+@router.get("/logs/jobs", response_model=AdminJobLogsResponse)
+def get_recent_jobs(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=200),
+    status_filter: str | None = Query(default=None),
+) -> AdminJobLogsResponse:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    id,
+                    job_type,
+                    status,
+                    requested_by_user_id,
+                    payload,
+                    created_at,
+                    updated_at
+                FROM jobs
+                WHERE (:status_filter IS NULL OR status = :status_filter)
+                ORDER BY created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {"status_filter": status_filter, "limit": limit},
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminJobLogRecord(**row) for row in rows]
+    return AdminJobLogsResponse(count=len(items), items=items)
+
+
+@router.get("/logs/evaluations", response_model=AdminEvaluationLogsResponse)
+def get_recent_evaluations(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=200),
+    status_filter: str | None = Query(default=None),
+) -> AdminEvaluationLogsResponse:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    id,
+                    defense_submission_id,
+                    attack_submission_id,
+                    scope,
+                    status,
+                    include_behavior_different,
+                    error,
+                    duration_ms,
+                    created_at,
+                    updated_at
+                FROM evaluation_runs
+                WHERE (:status_filter IS NULL OR status = :status_filter)
+                ORDER BY created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {"status_filter": status_filter, "limit": limit},
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminEvaluationLogRecord(**row) for row in rows]
+    return AdminEvaluationLogsResponse(count=len(items), items=items)
+
+
+@router.get("/sessions/active", response_model=AdminActiveSessionsResponse)
+def get_active_sessions(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=200),
+) -> AdminActiveSessionsResponse:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    us.id AS session_id,
+                    us.user_id,
+                    u.email,
+                    u.username,
+                    u.is_admin,
+                    us.created_at,
+                    us.last_seen_at,
+                    us.expires_at
+                FROM user_sessions us
+                JOIN users u
+                  ON u.id = us.user_id
+                WHERE us.revoked_at IS NULL
+                  AND us.expires_at > NOW()
+                  AND u.disabled_at IS NULL
+                ORDER BY COALESCE(us.last_seen_at, us.created_at) DESC
+                LIMIT :limit
+                """
+            ),
+            {"limit": limit},
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminActiveSessionRecord(**row) for row in rows]
+    return AdminActiveSessionsResponse(count=len(items), items=items)

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -49,6 +49,7 @@ router = APIRouter(
 
 
 def _request_meta(request: Request) -> tuple[str | None, str | None]:
+    """Return client IP and user-agent for audit logging."""
     client_ip = request.client.host if request.client else None
     user_agent = request.headers.get("user-agent")
     return client_ip, user_agent
@@ -64,6 +65,7 @@ def _log_admin_action_failure(
     target_email: str | None = None,
     metadata: dict[str, str | None] | None = None,
 ) -> None:
+    """Persist a failed admin action event with optional target metadata."""
     client_ip, user_agent = _request_meta(request)
     payload: dict[str, str | None] = dict(metadata or {})
     if target_user_id:
@@ -87,6 +89,7 @@ def get_overview(
     _: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminOverviewResponse:
+    """Return summary counts for the admin dashboard."""
     counts_row = (
         db.execute(
             text(
@@ -128,7 +131,9 @@ def get_users(
     search: str | None = Query(default=None),
     include_disabled: bool = Query(default=True),
 ) -> AdminUsersResponse:
+    """List users with last-seen and active session counts."""
     search_like = f"%{search}%" if search else None
+    # LATERAL joins let us compute per-user aggregates without duplicating rows.
     rows = (
         db.execute(
             text(
@@ -185,6 +190,7 @@ def get_users(
 def _submission_control_response(
     control,
 ) -> AdminSubmissionControlResponse:
+    """Normalize submission control state into the API response schema."""
     return AdminSubmissionControlResponse(
         manual_closed=control.manual_closed,
         close_at=control.close_at,
@@ -199,6 +205,7 @@ def get_submission_status(
     _: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminSubmissionControlResponse:
+    """Return the current submission close settings."""
     control = get_submission_control(db)
     return _submission_control_response(control)
 
@@ -209,6 +216,7 @@ def close_submissions(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminSubmissionControlResponse:
+    """Manually close submissions until reopened by an admin."""
     event_type = "admin.submissions.close"
     try:
         require_admin_origin(request, require_present=True)
@@ -247,6 +255,7 @@ def close_submissions(
 
         return _submission_control_response(control)
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -271,6 +280,7 @@ def open_submissions(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminSubmissionControlResponse:
+    """Reopen submissions that were manually closed."""
     event_type = "admin.submissions.open"
     try:
         require_admin_origin(request, require_present=True)
@@ -309,6 +319,7 @@ def open_submissions(
 
         return _submission_control_response(control)
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -334,6 +345,7 @@ def schedule_submissions_close(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminSubmissionControlResponse:
+    """Set or clear the scheduled submissions close time."""
     event_type = "admin.submissions.schedule"
     try:
         require_admin_origin(request, require_present=True)
@@ -372,6 +384,7 @@ def schedule_submissions_close(
 
         return _submission_control_response(control)
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -395,6 +408,7 @@ def schedule_submissions_close(
         )
         raise
 
+
 @router.get("/logs/jobs", response_model=AdminJobLogsResponse)
 def get_recent_jobs(
     _: AuthenticatedUser = Depends(require_admin_user),
@@ -402,6 +416,7 @@ def get_recent_jobs(
     limit: int = Query(default=50, ge=1, le=200),
     status_filter: str | None = Query(default=None),
 ) -> AdminJobLogsResponse:
+    """Return recent job records for the admin logs view."""
     rows = (
         db.execute(
             text(
@@ -437,6 +452,7 @@ def get_recent_evaluations(
     limit: int = Query(default=50, ge=1, le=200),
     status_filter: str | None = Query(default=None),
 ) -> AdminEvaluationLogsResponse:
+    """Return recent evaluation runs for the admin logs view."""
     rows = (
         db.execute(
             text(
@@ -474,6 +490,7 @@ def get_active_sessions(
     db: Session = Depends(get_db),
     limit: int = Query(default=50, ge=1, le=200),
 ) -> AdminActiveSessionsResponse:
+    """Return currently active user sessions."""
     rows = (
         db.execute(
             text(
@@ -515,6 +532,7 @@ def get_audit_logs(
     event_type: str | None = Query(default=None),
     success: bool | None = Query(default=None),
 ) -> AdminAuditLogsResponse:
+    """Return recent audit log entries."""
     rows = (
         db.execute(
             text(
@@ -557,6 +575,7 @@ def issue_action_token(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminActionTokenResponse:
+    """Issue a short-lived token required for admin write actions."""
     require_admin_origin(request, require_present=True)
     token, expires_at = issue_admin_action_token(db, session_id=str(current_user.session_id))
     return AdminActionTokenResponse(token=token, expires_at=expires_at)
@@ -569,6 +588,7 @@ def disable_user(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminUserActionResponse:
+    """Disable a user account and revoke any active sessions."""
     event_type = "admin.user.disable"
     try:
         require_admin_origin(request, require_present=True)
@@ -644,6 +664,7 @@ def disable_user(
             revoked_sessions=revoked,
         )
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -671,6 +692,7 @@ def enable_user(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminUserActionResponse:
+    """Re-enable a previously disabled user account."""
     event_type = "admin.user.enable"
     try:
         require_admin_origin(request, require_present=True)
@@ -728,6 +750,7 @@ def enable_user(
             disabled_at=row["disabled_at"],
         )
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -756,6 +779,7 @@ def set_admin_role(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminUserActionResponse:
+    """Promote or demote a user to admin based on the request payload."""
     event_type = "admin.user.promote" if req.is_admin else "admin.user.demote"
     try:
         require_admin_origin(request, require_present=True)
@@ -817,6 +841,7 @@ def set_admin_role(
             disabled_at=row["disabled_at"],
         )
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -844,6 +869,7 @@ def revoke_user_sessions(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminRevokeSessionsResponse:
+    """Revoke all active sessions for a user."""
     event_type = "admin.user.revoke_sessions"
     try:
         require_admin_origin(request, require_present=True)
@@ -908,6 +934,7 @@ def revoke_user_sessions(
 
         return AdminRevokeSessionsResponse(user_id=user_row["id"], revoked_count=revoked)
     except HTTPException as exc:
+        # Avoid rolling back on HTTP errors so the session stays usable in tests.
         _log_admin_action_failure(
             request=request,
             current_user=current_user,

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -13,6 +13,8 @@ from core.settings import get_settings
 from schemas.admin import (
     AdminActiveSessionRecord,
     AdminActiveSessionsResponse,
+    AdminAuditLogRecord,
+    AdminAuditLogsResponse,
     AdminEvaluationLogRecord,
     AdminEvaluationLogsResponse,
     AdminJobLogRecord,
@@ -175,3 +177,47 @@ def get_active_sessions(
 
     items = [AdminActiveSessionRecord(**row) for row in rows]
     return AdminActiveSessionsResponse(count=len(items), items=items)
+
+
+@router.get("/logs/audit", response_model=AdminAuditLogsResponse)
+def get_audit_logs(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=200),
+    event_type: str | None = Query(default=None),
+    success: bool | None = Query(default=None),
+) -> AdminAuditLogsResponse:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    id,
+                    event_type,
+                    user_id,
+                    email,
+                    ip_address,
+                    user_agent,
+                    success,
+                    message,
+                    metadata,
+                    created_at
+                FROM audit_logs
+                WHERE (:event_type IS NULL OR event_type = :event_type)
+                  AND (:success IS NULL OR success = :success)
+                ORDER BY created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {
+                "event_type": event_type,
+                "success": success,
+                "limit": limit,
+            },
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminAuditLogRecord(**row) for row in rows]
+    return AdminAuditLogsResponse(count=len(items), items=items)

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -51,6 +51,33 @@ def _request_meta(request: Request) -> tuple[str | None, str | None]:
     return client_ip, user_agent
 
 
+def _log_admin_action_failure(
+    *,
+    request: Request,
+    current_user: AuthenticatedUser,
+    event_type: str,
+    message: str,
+    target_user_id: UUID | None = None,
+    target_email: str | None = None,
+) -> None:
+    client_ip, user_agent = _request_meta(request)
+    metadata: dict[str, str] = {}
+    if target_user_id:
+        metadata["target_user_id"] = str(target_user_id)
+    if target_email:
+        metadata["target_email"] = target_email
+    log_audit_event(
+        event_type=event_type,
+        user_id=current_user.user_id,
+        email=current_user.email,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=False,
+        message=message,
+        metadata=metadata or None,
+    )
+
+
 @router.get("/overview", response_model=AdminOverviewResponse)
 def get_overview(
     _: AuthenticatedUser = Depends(require_admin_user),
@@ -325,78 +352,100 @@ def disable_user(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminUserActionResponse:
-    require_admin_origin(request, require_present=True)
-    action_token = require_admin_action_token(
-        request,
-        db=db,
-        session_id=str(current_user.session_id),
-    )
+    event_type = "admin.user.disable"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
 
-    if user_id == current_user.user_id:
-        raise HTTPException(status_code=400, detail="Cannot disable your own account")
+        if user_id == current_user.user_id:
+            raise HTTPException(status_code=400, detail="Cannot disable your own account")
 
-    now = datetime.now(timezone.utc)
-    row = (
-        db.execute(
+        now = datetime.now(timezone.utc)
+        row = (
+            db.execute(
+                text(
+                    """
+                    UPDATE users
+                    SET disabled_at = COALESCE(disabled_at, :now)
+                    WHERE id = :user_id
+                    RETURNING id, email, username, is_admin, disabled_at
+                    """
+                ),
+                {"user_id": str(user_id), "now": now},
+            )
+            .mappings()
+            .fetchone()
+        )
+
+        if row is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        revoked = db.execute(
             text(
                 """
-                UPDATE users
-                SET disabled_at = COALESCE(disabled_at, :now)
-                WHERE id = :user_id
-                RETURNING id, email, username, is_admin, disabled_at
+                UPDATE user_sessions
+                SET revoked_at = :now
+                WHERE user_id = :user_id
+                  AND revoked_at IS NULL
                 """
             ),
             {"user_id": str(user_id), "now": now},
+        ).rowcount
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
         )
-        .mappings()
-        .fetchone()
-    )
+        db.commit()
 
-    if row is None:
-        raise HTTPException(status_code=404, detail="User not found")
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "target_user_id": str(row["id"]),
+                "target_email": row["email"],
+                "revoked_sessions": revoked,
+            },
+        )
 
-    revoked = db.execute(
-        text(
-            """
-            UPDATE user_sessions
-            SET revoked_at = :now
-            WHERE user_id = :user_id
-              AND revoked_at IS NULL
-            """
-        ),
-        {"user_id": str(user_id), "now": now},
-    ).rowcount
-
-    consume_admin_action_token(
-        db,
-        session_id=str(current_user.session_id),
-        token=action_token,
-    )
-    db.commit()
-
-    client_ip, user_agent = _request_meta(request)
-    log_audit_event(
-        event_type="admin.user.disable",
-        user_id=current_user.user_id,
-        email=current_user.email,
-        ip_address=client_ip,
-        user_agent=user_agent,
-        success=True,
-        metadata={
-            "target_user_id": str(row["id"]),
-            "target_email": row["email"],
-            "revoked_sessions": revoked,
-        },
-    )
-
-    return AdminUserActionResponse(
-        user_id=row["id"],
-        email=row["email"],
-        username=row["username"],
-        is_admin=row["is_admin"],
-        disabled_at=row["disabled_at"],
-        revoked_sessions=revoked,
-    )
+        return AdminUserActionResponse(
+            user_id=row["id"],
+            email=row["email"],
+            username=row["username"],
+            is_admin=row["is_admin"],
+            disabled_at=row["disabled_at"],
+            revoked_sessions=revoked,
+        )
+    except HTTPException as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            target_user_id=user_id,
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            target_user_id=user_id,
+        )
+        raise
 
 
 @router.post("/users/{user_id}/enable", response_model=AdminUserActionResponse)
@@ -406,60 +455,82 @@ def enable_user(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminUserActionResponse:
-    require_admin_origin(request, require_present=True)
-    action_token = require_admin_action_token(
-        request,
-        db=db,
-        session_id=str(current_user.session_id),
-    )
-
-    row = (
-        db.execute(
-            text(
-                """
-                UPDATE users
-                SET disabled_at = NULL
-                WHERE id = :user_id
-                RETURNING id, email, username, is_admin, disabled_at
-                """
-            ),
-            {"user_id": str(user_id)},
+    event_type = "admin.user.enable"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
         )
-        .mappings()
-        .fetchone()
-    )
 
-    if row is None:
-        raise HTTPException(status_code=404, detail="User not found")
+        row = (
+            db.execute(
+                text(
+                    """
+                    UPDATE users
+                    SET disabled_at = NULL
+                    WHERE id = :user_id
+                    RETURNING id, email, username, is_admin, disabled_at
+                    """
+                ),
+                {"user_id": str(user_id)},
+            )
+            .mappings()
+            .fetchone()
+        )
 
-    consume_admin_action_token(
-        db,
-        session_id=str(current_user.session_id),
-        token=action_token,
-    )
-    db.commit()
+        if row is None:
+            raise HTTPException(status_code=404, detail="User not found")
 
-    client_ip, user_agent = _request_meta(request)
-    log_audit_event(
-        event_type="admin.user.enable",
-        user_id=current_user.user_id,
-        email=current_user.email,
-        ip_address=client_ip,
-        user_agent=user_agent,
-        success=True,
-        metadata={
-            "target_user_id": str(row["id"]),
-            "target_email": row["email"],
-        },
-    )
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
 
-    return AdminUserActionResponse(
-        user_id=row["id"],
-        email=row["email"],
-        username=row["username"],
-        is_admin=row["is_admin"],
-        disabled_at=row["disabled_at"],
-    )
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "target_user_id": str(row["id"]),
+                "target_email": row["email"],
+            },
+        )
+
+        return AdminUserActionResponse(
+            user_id=row["id"],
+            email=row["email"],
+            username=row["username"],
+            is_admin=row["is_admin"],
+            disabled_at=row["disabled_at"],
+        )
+    except HTTPException as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            target_user_id=user_id,
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            target_user_id=user_id,
+        )
+        raise
 
 
 @router.post("/users/{user_id}/admin", response_model=AdminUserActionResponse)
@@ -470,65 +541,86 @@ def set_admin_role(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminUserActionResponse:
-    require_admin_origin(request, require_present=True)
-    action_token = require_admin_action_token(
-        request,
-        db=db,
-        session_id=str(current_user.session_id),
-    )
-
-    if user_id == current_user.user_id and not req.is_admin:
-        raise HTTPException(status_code=400, detail="Cannot remove your own admin privileges")
-
-    row = (
-        db.execute(
-            text(
-                """
-                UPDATE users
-                SET is_admin = :is_admin
-                WHERE id = :user_id
-                RETURNING id, email, username, is_admin, disabled_at
-                """
-            ),
-            {"user_id": str(user_id), "is_admin": req.is_admin},
-        )
-        .mappings()
-        .fetchone()
-    )
-
-    if row is None:
-        raise HTTPException(status_code=404, detail="User not found")
-
-    consume_admin_action_token(
-        db,
-        session_id=str(current_user.session_id),
-        token=action_token,
-    )
-    db.commit()
-
     event_type = "admin.user.promote" if req.is_admin else "admin.user.demote"
-    client_ip, user_agent = _request_meta(request)
-    log_audit_event(
-        event_type=event_type,
-        user_id=current_user.user_id,
-        email=current_user.email,
-        ip_address=client_ip,
-        user_agent=user_agent,
-        success=True,
-        metadata={
-            "target_user_id": str(row["id"]),
-            "target_email": row["email"],
-            "is_admin": row["is_admin"],
-        },
-    )
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
 
-    return AdminUserActionResponse(
-        user_id=row["id"],
-        email=row["email"],
-        username=row["username"],
-        is_admin=row["is_admin"],
-        disabled_at=row["disabled_at"],
-    )
+        if user_id == current_user.user_id and not req.is_admin:
+            raise HTTPException(status_code=400, detail="Cannot remove your own admin privileges")
+
+        row = (
+            db.execute(
+                text(
+                    """
+                    UPDATE users
+                    SET is_admin = :is_admin
+                    WHERE id = :user_id
+                    RETURNING id, email, username, is_admin, disabled_at
+                    """
+                ),
+                {"user_id": str(user_id), "is_admin": req.is_admin},
+            )
+            .mappings()
+            .fetchone()
+        )
+
+        if row is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
+
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "target_user_id": str(row["id"]),
+                "target_email": row["email"],
+                "is_admin": row["is_admin"],
+            },
+        )
+
+        return AdminUserActionResponse(
+            user_id=row["id"],
+            email=row["email"],
+            username=row["username"],
+            is_admin=row["is_admin"],
+            disabled_at=row["disabled_at"],
+        )
+    except HTTPException as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            target_user_id=user_id,
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            target_user_id=user_id,
+        )
+        raise
 
 
 @router.post("/users/{user_id}/sessions/revoke", response_model=AdminRevokeSessionsResponse)
@@ -538,64 +630,86 @@ def revoke_user_sessions(
     current_user: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
 ) -> AdminRevokeSessionsResponse:
-    require_admin_origin(request, require_present=True)
-    action_token = require_admin_action_token(
-        request,
-        db=db,
-        session_id=str(current_user.session_id),
-    )
+    event_type = "admin.user.revoke_sessions"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
 
-    user_row = (
-        db.execute(
+        user_row = (
+            db.execute(
+                text(
+                    """
+                    SELECT id, email
+                    FROM users
+                    WHERE id = :user_id
+                    """
+                ),
+                {"user_id": str(user_id)},
+            )
+            .mappings()
+            .fetchone()
+        )
+
+        if user_row is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        now = datetime.now(timezone.utc)
+        revoked = db.execute(
             text(
                 """
-                SELECT id, email
-                FROM users
-                WHERE id = :user_id
+                UPDATE user_sessions
+                SET revoked_at = :now
+                WHERE user_id = :user_id
+                  AND revoked_at IS NULL
                 """
             ),
-            {"user_id": str(user_id)},
+            {"user_id": str(user_id), "now": now},
+        ).rowcount
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
         )
-        .mappings()
-        .fetchone()
-    )
+        db.commit()
 
-    if user_row is None:
-        raise HTTPException(status_code=404, detail="User not found")
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "target_user_id": str(user_row["id"]),
+                "target_email": user_row["email"],
+                "revoked_sessions": revoked,
+            },
+        )
 
-    now = datetime.now(timezone.utc)
-    revoked = db.execute(
-        text(
-            """
-            UPDATE user_sessions
-            SET revoked_at = :now
-            WHERE user_id = :user_id
-              AND revoked_at IS NULL
-            """
-        ),
-        {"user_id": str(user_id), "now": now},
-    ).rowcount
-
-    consume_admin_action_token(
-        db,
-        session_id=str(current_user.session_id),
-        token=action_token,
-    )
-    db.commit()
-
-    client_ip, user_agent = _request_meta(request)
-    log_audit_event(
-        event_type="admin.user.revoke_sessions",
-        user_id=current_user.user_id,
-        email=current_user.email,
-        ip_address=client_ip,
-        user_agent=user_agent,
-        success=True,
-        metadata={
-            "target_user_id": str(user_row["id"]),
-            "target_email": user_row["email"],
-            "revoked_sessions": revoked,
-        },
-    )
-
-    return AdminRevokeSessionsResponse(user_id=user_row["id"], revoked_count=revoked)
+        return AdminRevokeSessionsResponse(user_id=user_row["id"], revoked_count=revoked)
+    except HTTPException as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            target_user_id=user_id,
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            target_user_id=user_id,
+        )
+        raise

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -19,6 +19,7 @@ from core.audit import log_audit_event
 from core.auth import AuthenticatedUser
 from core.database import get_db
 from core.settings import get_settings
+from core.submission_control import get_submission_control, set_close_at, set_manual_closed
 from schemas.admin import (
     AdminActiveSessionRecord,
     AdminActiveSessionsResponse,
@@ -32,6 +33,8 @@ from schemas.admin import (
     AdminOverviewResponse,
     AdminRevokeSessionsResponse,
     AdminSetAdminRequest,
+    AdminSubmissionControlResponse,
+    AdminSubmissionScheduleRequest,
     AdminSystemCounts,
     AdminUserRecord,
     AdminUserActionResponse,
@@ -59,13 +62,14 @@ def _log_admin_action_failure(
     message: str,
     target_user_id: UUID | None = None,
     target_email: str | None = None,
+    metadata: dict[str, str | None] | None = None,
 ) -> None:
     client_ip, user_agent = _request_meta(request)
-    metadata: dict[str, str] = {}
+    payload: dict[str, str | None] = dict(metadata or {})
     if target_user_id:
-        metadata["target_user_id"] = str(target_user_id)
+        payload["target_user_id"] = str(target_user_id)
     if target_email:
-        metadata["target_email"] = target_email
+        payload["target_email"] = target_email
     log_audit_event(
         event_type=event_type,
         user_id=current_user.user_id,
@@ -74,7 +78,7 @@ def _log_admin_action_failure(
         user_agent=user_agent,
         success=False,
         message=message,
-        metadata=metadata or None,
+        metadata=payload or None,
     )
 
 
@@ -177,6 +181,219 @@ def get_users(
     items = [AdminUserRecord(**row) for row in rows]
     return AdminUsersResponse(count=len(items), items=items)
 
+
+def _submission_control_response(
+    control,
+) -> AdminSubmissionControlResponse:
+    return AdminSubmissionControlResponse(
+        manual_closed=control.manual_closed,
+        close_at=control.close_at,
+        is_closed=control.is_closed(),
+        updated_at=control.updated_at,
+        updated_by=control.updated_by,
+    )
+
+
+@router.get("/submissions/status", response_model=AdminSubmissionControlResponse)
+def get_submission_status(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminSubmissionControlResponse:
+    control = get_submission_control(db)
+    return _submission_control_response(control)
+
+
+@router.post("/submissions/close", response_model=AdminSubmissionControlResponse)
+def close_submissions(
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminSubmissionControlResponse:
+    event_type = "admin.submissions.close"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
+
+        control = set_manual_closed(
+            db,
+            closed=True,
+            updated_by=str(current_user.user_id),
+        )
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
+
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "manual_closed": str(control.manual_closed),
+                "close_at": control.close_at.isoformat() if control.close_at else None,
+            },
+        )
+
+        return _submission_control_response(control)
+    except HTTPException as exc:
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+        )
+        raise
+
+
+@router.post("/submissions/open", response_model=AdminSubmissionControlResponse)
+def open_submissions(
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminSubmissionControlResponse:
+    event_type = "admin.submissions.open"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
+
+        control = set_manual_closed(
+            db,
+            closed=False,
+            updated_by=str(current_user.user_id),
+        )
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
+
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "manual_closed": str(control.manual_closed),
+                "close_at": control.close_at.isoformat() if control.close_at else None,
+            },
+        )
+
+        return _submission_control_response(control)
+    except HTTPException as exc:
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+        )
+        raise
+
+
+@router.post("/submissions/schedule", response_model=AdminSubmissionControlResponse)
+def schedule_submissions_close(
+    req: AdminSubmissionScheduleRequest,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminSubmissionControlResponse:
+    event_type = "admin.submissions.schedule"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
+
+        control = set_close_at(
+            db,
+            close_at=req.close_at,
+            updated_by=str(current_user.user_id),
+        )
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
+
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "manual_closed": str(control.manual_closed),
+                "close_at": control.close_at.isoformat() if control.close_at else None,
+            },
+        )
+
+        return _submission_control_response(control)
+    except HTTPException as exc:
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            metadata={
+                "close_at": req.close_at.isoformat() if req.close_at else None,
+            },
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            metadata={
+                "close_at": req.close_at.isoformat() if req.close_at else None,
+            },
+        )
+        raise
 
 @router.get("/logs/jobs", response_model=AdminJobLogsResponse)
 def get_recent_jobs(

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -427,7 +427,6 @@ def disable_user(
             revoked_sessions=revoked,
         )
     except HTTPException as exc:
-        db.rollback()
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -512,7 +511,6 @@ def enable_user(
             disabled_at=row["disabled_at"],
         )
     except HTTPException as exc:
-        db.rollback()
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -602,7 +600,6 @@ def set_admin_role(
             disabled_at=row["disabled_at"],
         )
     except HTTPException as exc:
-        db.rollback()
         _log_admin_action_failure(
             request=request,
             current_user=current_user,
@@ -694,7 +691,6 @@ def revoke_user_sessions(
 
         return AdminRevokeSessionsResponse(user_id=user_row["id"], revoked_count=revoked)
     except HTTPException as exc:
-        db.rollback()
         _log_admin_action_failure(
             request=request,
             current_user=current_user,

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from core.admin import require_admin_user, require_localhost_request
+from core.admin import (
+    consume_admin_action_token,
+    issue_admin_action_token,
+    require_admin_action_token,
+    require_admin_origin,
+    require_admin_user,
+    require_localhost_request,
+)
+from core.audit import log_audit_event
 from core.auth import AuthenticatedUser
 from core.database import get_db
 from core.settings import get_settings
 from schemas.admin import (
     AdminActiveSessionRecord,
     AdminActiveSessionsResponse,
+    AdminActionTokenResponse,
     AdminAuditLogRecord,
     AdminAuditLogsResponse,
     AdminEvaluationLogRecord,
@@ -20,7 +30,10 @@ from schemas.admin import (
     AdminJobLogRecord,
     AdminJobLogsResponse,
     AdminOverviewResponse,
+    AdminRevokeSessionsResponse,
+    AdminSetAdminRequest,
     AdminSystemCounts,
+    AdminUserActionResponse,
 )
 
 router = APIRouter(
@@ -28,6 +41,12 @@ router = APIRouter(
     tags=["admin"],
     dependencies=[Depends(require_localhost_request)],
 )
+
+
+def _request_meta(request: Request) -> tuple[str | None, str | None]:
+    client_ip = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
+    return client_ip, user_agent
 
 
 @router.get("/overview", response_model=AdminOverviewResponse)
@@ -221,3 +240,297 @@ def get_audit_logs(
 
     items = [AdminAuditLogRecord(**row) for row in rows]
     return AdminAuditLogsResponse(count=len(items), items=items)
+
+
+@router.post("/actions/token", response_model=AdminActionTokenResponse)
+def issue_action_token(
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminActionTokenResponse:
+    require_admin_origin(request, require_present=True)
+    token, expires_at = issue_admin_action_token(db, session_id=str(current_user.session_id))
+    return AdminActionTokenResponse(token=token, expires_at=expires_at)
+
+
+@router.post("/users/{user_id}/disable", response_model=AdminUserActionResponse)
+def disable_user(
+    user_id: UUID,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminUserActionResponse:
+    require_admin_origin(request, require_present=True)
+    action_token = require_admin_action_token(
+        request,
+        db=db,
+        session_id=str(current_user.session_id),
+    )
+
+    if user_id == current_user.user_id:
+        raise HTTPException(status_code=400, detail="Cannot disable your own account")
+
+    now = datetime.now(timezone.utc)
+    row = (
+        db.execute(
+            text(
+                """
+                UPDATE users
+                SET disabled_at = COALESCE(disabled_at, :now)
+                WHERE id = :user_id
+                RETURNING id, email, username, is_admin, disabled_at
+                """
+            ),
+            {"user_id": str(user_id), "now": now},
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    revoked = db.execute(
+        text(
+            """
+            UPDATE user_sessions
+            SET revoked_at = :now
+            WHERE user_id = :user_id
+              AND revoked_at IS NULL
+            """
+        ),
+        {"user_id": str(user_id), "now": now},
+    ).rowcount
+
+    consume_admin_action_token(
+        db,
+        session_id=str(current_user.session_id),
+        token=action_token,
+    )
+    db.commit()
+
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type="admin.user.disable",
+        user_id=current_user.user_id,
+        email=current_user.email,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+        metadata={
+            "target_user_id": str(row["id"]),
+            "target_email": row["email"],
+            "revoked_sessions": revoked,
+        },
+    )
+
+    return AdminUserActionResponse(
+        user_id=row["id"],
+        email=row["email"],
+        username=row["username"],
+        is_admin=row["is_admin"],
+        disabled_at=row["disabled_at"],
+        revoked_sessions=revoked,
+    )
+
+
+@router.post("/users/{user_id}/enable", response_model=AdminUserActionResponse)
+def enable_user(
+    user_id: UUID,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminUserActionResponse:
+    require_admin_origin(request, require_present=True)
+    action_token = require_admin_action_token(
+        request,
+        db=db,
+        session_id=str(current_user.session_id),
+    )
+
+    row = (
+        db.execute(
+            text(
+                """
+                UPDATE users
+                SET disabled_at = NULL
+                WHERE id = :user_id
+                RETURNING id, email, username, is_admin, disabled_at
+                """
+            ),
+            {"user_id": str(user_id)},
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    consume_admin_action_token(
+        db,
+        session_id=str(current_user.session_id),
+        token=action_token,
+    )
+    db.commit()
+
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type="admin.user.enable",
+        user_id=current_user.user_id,
+        email=current_user.email,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+        metadata={
+            "target_user_id": str(row["id"]),
+            "target_email": row["email"],
+        },
+    )
+
+    return AdminUserActionResponse(
+        user_id=row["id"],
+        email=row["email"],
+        username=row["username"],
+        is_admin=row["is_admin"],
+        disabled_at=row["disabled_at"],
+    )
+
+
+@router.post("/users/{user_id}/admin", response_model=AdminUserActionResponse)
+def set_admin_role(
+    user_id: UUID,
+    req: AdminSetAdminRequest,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminUserActionResponse:
+    require_admin_origin(request, require_present=True)
+    action_token = require_admin_action_token(
+        request,
+        db=db,
+        session_id=str(current_user.session_id),
+    )
+
+    if user_id == current_user.user_id and not req.is_admin:
+        raise HTTPException(status_code=400, detail="Cannot remove your own admin privileges")
+
+    row = (
+        db.execute(
+            text(
+                """
+                UPDATE users
+                SET is_admin = :is_admin
+                WHERE id = :user_id
+                RETURNING id, email, username, is_admin, disabled_at
+                """
+            ),
+            {"user_id": str(user_id), "is_admin": req.is_admin},
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    consume_admin_action_token(
+        db,
+        session_id=str(current_user.session_id),
+        token=action_token,
+    )
+    db.commit()
+
+    event_type = "admin.user.promote" if req.is_admin else "admin.user.demote"
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type=event_type,
+        user_id=current_user.user_id,
+        email=current_user.email,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+        metadata={
+            "target_user_id": str(row["id"]),
+            "target_email": row["email"],
+            "is_admin": row["is_admin"],
+        },
+    )
+
+    return AdminUserActionResponse(
+        user_id=row["id"],
+        email=row["email"],
+        username=row["username"],
+        is_admin=row["is_admin"],
+        disabled_at=row["disabled_at"],
+    )
+
+
+@router.post("/users/{user_id}/sessions/revoke", response_model=AdminRevokeSessionsResponse)
+def revoke_user_sessions(
+    user_id: UUID,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminRevokeSessionsResponse:
+    require_admin_origin(request, require_present=True)
+    action_token = require_admin_action_token(
+        request,
+        db=db,
+        session_id=str(current_user.session_id),
+    )
+
+    user_row = (
+        db.execute(
+            text(
+                """
+                SELECT id, email
+                FROM users
+                WHERE id = :user_id
+                """
+            ),
+            {"user_id": str(user_id)},
+        )
+        .mappings()
+        .fetchone()
+    )
+
+    if user_row is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    now = datetime.now(timezone.utc)
+    revoked = db.execute(
+        text(
+            """
+            UPDATE user_sessions
+            SET revoked_at = :now
+            WHERE user_id = :user_id
+              AND revoked_at IS NULL
+            """
+        ),
+        {"user_id": str(user_id), "now": now},
+    ).rowcount
+
+    consume_admin_action_token(
+        db,
+        session_id=str(current_user.session_id),
+        token=action_token,
+    )
+    db.commit()
+
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type="admin.user.revoke_sessions",
+        user_id=current_user.user_id,
+        email=current_user.email,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+        metadata={
+            "target_user_id": str(user_row["id"]),
+            "target_email": user_row["email"],
+            "revoked_sessions": revoked,
+        },
+    )
+
+    return AdminRevokeSessionsResponse(user_id=user_row["id"], revoked_count=revoked)

--- a/services/api/routers/auth.py
+++ b/services/api/routers/auth.py
@@ -185,7 +185,7 @@ def login(
         return LoginResponse(
             authenticated=False,
             requires_registration=True,
-            required_registration_fields=required_fields,
+            required_registration_fields=REQUIRED_REGISTRATION_FIELDS,
         )
 
     session_token = create_session(db, user_id=row["id"])

--- a/services/api/routers/auth.py
+++ b/services/api/routers/auth.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from core.audit import log_audit_event
 from core.auth import AuthenticatedUser, create_session, get_authenticated_user, revoke_session_by_id
 from core.database import get_db
 from core.settings import get_settings
@@ -29,6 +30,12 @@ from schemas.auth import (
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 logger = logging.getLogger(__name__)
+
+
+def _request_meta(request: Request) -> tuple[str | None, str | None]:
+    client_ip = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
+    return client_ip, user_agent
 
 
 def _to_user_response(
@@ -82,6 +89,7 @@ def _clear_session_cookie(response: Response) -> None:
 def login(
     req: LoginRequest,
     response: Response,
+    request: Request,
     db: Session = Depends(get_db),
 ) -> LoginResponse:
     """Authenticate an email-only user and issue a session token."""
@@ -115,9 +123,27 @@ def login(
             {"email": req.email},
         ).fetchone()
         if disabled is not None:
+            client_ip, user_agent = _request_meta(request)
+            log_audit_event(
+                event_type="auth.login",
+                email=req.email,
+                ip_address=client_ip,
+                user_agent=user_agent,
+                success=False,
+                message="disabled account",
+            )
             logger.warning("Login attempt for disabled account")
             raise HTTPException(status_code=403, detail="User account is disabled")
 
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type="auth.login",
+            email=req.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=False,
+            message="unknown email",
+        )
         logger.info("Login requested for unknown email")
         return LoginResponse(
             authenticated=False,
@@ -128,6 +154,15 @@ def login(
     session_token = create_session(db, user_id=row["id"])
     _set_session_cookie(response, access_token=session_token.access_token, expires_at=session_token.expires_at)
 
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type="auth.login",
+        user_id=row["id"],
+        email=row["email"],
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+    )
     logger.info("Login success for user %s (admin=%s)", row["id"], row["is_admin"])
     return LoginResponse(
         authenticated=True,
@@ -146,6 +181,7 @@ def login(
 def register(
     req: RegisterRequest,
     response: Response,
+    request: Request,
     db: Session = Depends(get_db),
 ) -> SessionResponse:
     """Register a new user and issue a session token."""
@@ -165,7 +201,25 @@ def register(
     )
     if existing_email is not None:
         if existing_email["disabled_at"] is None:
+            client_ip, user_agent = _request_meta(request)
+            log_audit_event(
+                event_type="auth.register",
+                email=req.email,
+                ip_address=client_ip,
+                user_agent=user_agent,
+                success=False,
+                message="email already registered",
+            )
             raise HTTPException(status_code=409, detail="Email is already registered")
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type="auth.register",
+            email=req.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=False,
+            message="email belongs to disabled user",
+        )
         raise HTTPException(status_code=409, detail="Email belongs to a disabled user")
 
     existing_username = db.execute(
@@ -179,6 +233,15 @@ def register(
         {"username": req.username},
     ).fetchone()
     if existing_username is not None:
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type="auth.register",
+            email=req.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=False,
+            message="username already taken",
+        )
         raise HTTPException(status_code=409, detail="Username is already taken")
 
     try:
@@ -219,6 +282,15 @@ def register(
         db.commit()
     except IntegrityError:
         db.rollback()
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type="auth.register",
+            email=req.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=False,
+            message="duplicate email or username",
+        )
         logger.warning("Registration failed due to duplicate email or username")
         raise HTTPException(status_code=409, detail="Email or username is already registered") from None
     except HTTPException:
@@ -227,6 +299,15 @@ def register(
 
     _set_session_cookie(response, access_token=session_token.access_token, expires_at=session_token.expires_at)
 
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type="auth.register",
+        user_id=user_row["id"],
+        email=user_row["email"],
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+    )
     logger.info("Registered new user %s", user_row["id"])
     return SessionResponse(
         expires_at=session_token.expires_at,
@@ -242,6 +323,7 @@ def register(
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 def logout(
     response: Response,
+    request: Request,
     current_user: AuthenticatedUser = Depends(get_authenticated_user),
     db: Session = Depends(get_db),
 ) -> Response:
@@ -249,6 +331,15 @@ def logout(
     revoke_session_by_id(db, session_id=current_user.session_id, commit=True)
     _clear_session_cookie(response)
     response.status_code = status.HTTP_204_NO_CONTENT
+    client_ip, user_agent = _request_meta(request)
+    log_audit_event(
+        event_type="auth.logout",
+        user_id=current_user.user_id,
+        email=current_user.email,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        success=True,
+    )
     logger.info("Logout for user %s", current_user.user_id)
     return response
 

--- a/services/api/routers/auth.py
+++ b/services/api/routers/auth.py
@@ -7,6 +7,7 @@ cookie management and session persistence.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import text
@@ -27,6 +28,7 @@ from schemas.auth import (
 )
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
 
 
 def _to_user_response(
@@ -113,8 +115,10 @@ def login(
             {"email": req.email},
         ).fetchone()
         if disabled is not None:
+            logger.warning("Login attempt for disabled account")
             raise HTTPException(status_code=403, detail="User account is disabled")
 
+        logger.info("Login requested for unknown email")
         return LoginResponse(
             authenticated=False,
             requires_registration=True,
@@ -124,6 +128,7 @@ def login(
     session_token = create_session(db, user_id=row["id"])
     _set_session_cookie(response, access_token=session_token.access_token, expires_at=session_token.expires_at)
 
+    logger.info("Login success for user %s (admin=%s)", row["id"], row["is_admin"])
     return LoginResponse(
         authenticated=True,
         requires_registration=False,
@@ -214,6 +219,7 @@ def register(
         db.commit()
     except IntegrityError:
         db.rollback()
+        logger.warning("Registration failed due to duplicate email or username")
         raise HTTPException(status_code=409, detail="Email or username is already registered") from None
     except HTTPException:
         db.rollback()
@@ -221,6 +227,7 @@ def register(
 
     _set_session_cookie(response, access_token=session_token.access_token, expires_at=session_token.expires_at)
 
+    logger.info("Registered new user %s", user_row["id"])
     return SessionResponse(
         expires_at=session_token.expires_at,
         user=_to_user_response(
@@ -242,6 +249,7 @@ def logout(
     revoke_session_by_id(db, session_id=current_user.session_id, commit=True)
     _clear_session_cookie(response)
     response.status_code = status.HTTP_204_NO_CONTENT
+    logger.info("Logout for user %s", current_user.user_id)
     return response
 
 

--- a/services/api/routers/queue.py
+++ b/services/api/routers/queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Union
 from uuid import UUID
 
@@ -21,6 +22,7 @@ from schemas.jobs import (
 
 
 router = APIRouter(tags=["queue"])
+logger = logging.getLogger(__name__)
 
 
 def _insert_job(
@@ -53,6 +55,7 @@ def _insert_job(
         raise HTTPException(status_code=500, detail="Failed to create job")
 
     db.commit()
+    logger.info("Created job %s type=%s for user %s", row[0], job_type, requested_by_user_id)
     return row[0]
 
 
@@ -99,6 +102,7 @@ def enqueue_defense_job(
         requested_by_user_id=current_user.user_id,
     )
     celery_task_id = _publish_task(job_type=JobType.DEFENSE, job_id=job_id, payload=payload)
+    logger.info("Published defense job %s (celery=%s)", job_id, celery_task_id)
 
     return EnqueueJobResponse(job_id=job_id, status="queued", job_type=JobType.DEFENSE, celery_task_id=celery_task_id)
 
@@ -124,6 +128,7 @@ def enqueue_attack_job(
         requested_by_user_id=current_user.user_id,
     )
     celery_task_id = _publish_task(job_type=JobType.ATTACK, job_id=job_id, payload=payload)
+    logger.info("Published attack job %s (celery=%s)", job_id, celery_task_id)
 
     return EnqueueJobResponse(job_id=job_id, status="queued", job_type=JobType.ATTACK, celery_task_id=celery_task_id)
 
@@ -169,4 +174,5 @@ def dispatch_job(
         requested_by_user_id=current_user.user_id,
     )
     celery_task_id = _publish_task(job_type=job_type, job_id=job_id, payload=payload)
+    logger.info("Dispatched job %s type=%s (celery=%s)", job_id, job_type.value, celery_task_id)
     return EnqueueJobResponse(job_id=job_id, status="queued", job_type=job_type, celery_task_id=celery_task_id)

--- a/services/api/routers/submissions.py
+++ b/services/api/routers/submissions.py
@@ -101,6 +101,7 @@ def create_defense_docker(
     Submit defense from Docker Hub or registry.
     Automatically enqueues validation job.
     """
+    # Enforce admin-controlled submission window before accepting new work.
     ensure_submissions_open(db)
     # 1. Validate format
     validate_docker_image_format(req.docker_image)
@@ -192,6 +193,7 @@ def create_defense_github(
     Submit defense from GitHub repository.
     Automatically enqueues validation job.
     """
+    # Enforce admin-controlled submission window before accepting new work.
     ensure_submissions_open(db)
     # 1. Validate format
     validate_github_url_format(req.git_repo)
@@ -285,6 +287,7 @@ async def create_defense_zip(
     Submit defense from ZIP file upload.
     Uploads to MinIO, automatically enqueues validation job.
     """
+    # Enforce admin-controlled submission window before accepting new work.
     ensure_submissions_open(db)
     settings = get_settings()
 
@@ -440,6 +443,7 @@ async def create_attack_zip(
     Password must be 'infected'.
     Uploads to MinIO, automatically enqueues validation job.
     """
+    # Enforce admin-controlled submission window before accepting new work.
     ensure_submissions_open(db)
     settings = get_settings()
 

--- a/services/api/routers/submissions.py
+++ b/services/api/routers/submissions.py
@@ -23,6 +23,7 @@ from core.submissions import (
     validate_github_url_format,
     validate_semver_format,
 )
+from core.submission_control import ensure_submissions_open
 from routers.queue import _insert_job, _publish_task
 from schemas.jobs import JobType
 from schemas.submissions import (
@@ -100,6 +101,7 @@ def create_defense_docker(
     Submit defense from Docker Hub or registry.
     Automatically enqueues validation job.
     """
+    ensure_submissions_open(db)
     # 1. Validate format
     validate_docker_image_format(req.docker_image)
     validate_semver_format(req.version)
@@ -190,6 +192,7 @@ def create_defense_github(
     Submit defense from GitHub repository.
     Automatically enqueues validation job.
     """
+    ensure_submissions_open(db)
     # 1. Validate format
     validate_github_url_format(req.git_repo)
     validate_semver_format(req.version)
@@ -282,6 +285,7 @@ async def create_defense_zip(
     Submit defense from ZIP file upload.
     Uploads to MinIO, automatically enqueues validation job.
     """
+    ensure_submissions_open(db)
     settings = get_settings()
 
     # 1. Validate file
@@ -436,6 +440,7 @@ async def create_attack_zip(
     Password must be 'infected'.
     Uploads to MinIO, automatically enqueues validation job.
     """
+    ensure_submissions_open(db)
     settings = get_settings()
 
     # 1. Validate file

--- a/services/api/schemas/admin.py
+++ b/services/api/schemas/admin.py
@@ -70,3 +70,21 @@ class AdminActiveSessionRecord(BaseModel):
 class AdminActiveSessionsResponse(BaseModel):
     count: int
     items: list[AdminActiveSessionRecord]
+
+
+class AdminAuditLogRecord(BaseModel):
+    id: UUID
+    event_type: str
+    user_id: UUID | None = None
+    email: str | None = None
+    ip_address: str | None = None
+    user_agent: str | None = None
+    success: bool | None = None
+    message: str | None = None
+    metadata: dict | None = None
+    created_at: datetime
+
+
+class AdminAuditLogsResponse(BaseModel):
+    count: int
+    items: list[AdminAuditLogRecord]

--- a/services/api/schemas/admin.py
+++ b/services/api/schemas/admin.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class AdminSystemCounts(BaseModel):
+    users_total: int
+    users_active: int
+    sessions_active: int
+    submissions_total: int
+    evaluation_runs_total: int
+    jobs_queued: int
+    jobs_running: int
+    jobs_failed: int
+
+
+class AdminOverviewResponse(BaseModel):
+    generated_at: datetime
+    environment: str
+    counts: AdminSystemCounts
+
+
+class AdminJobLogRecord(BaseModel):
+    id: UUID
+    job_type: str
+    status: str
+    requested_by_user_id: UUID | None = None
+    payload: dict | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AdminJobLogsResponse(BaseModel):
+    count: int
+    items: list[AdminJobLogRecord]
+
+
+class AdminEvaluationLogRecord(BaseModel):
+    id: UUID
+    defense_submission_id: UUID
+    attack_submission_id: UUID
+    scope: str | None = None
+    status: str | None = None
+    include_behavior_different: bool | None = None
+    error: str | None = None
+    duration_ms: int | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AdminEvaluationLogsResponse(BaseModel):
+    count: int
+    items: list[AdminEvaluationLogRecord]
+
+
+class AdminActiveSessionRecord(BaseModel):
+    session_id: UUID
+    user_id: UUID
+    email: str
+    username: str
+    is_admin: bool
+    created_at: datetime
+    last_seen_at: datetime | None = None
+    expires_at: datetime
+
+
+class AdminActiveSessionsResponse(BaseModel):
+    count: int
+    items: list[AdminActiveSessionRecord]

--- a/services/api/schemas/admin.py
+++ b/services/api/schemas/admin.py
@@ -90,6 +90,22 @@ class AdminAuditLogsResponse(BaseModel):
     items: list[AdminAuditLogRecord]
 
 
+class AdminUserRecord(BaseModel):
+    id: UUID
+    email: str
+    username: str
+    is_admin: bool
+    created_at: datetime
+    disabled_at: datetime | None = None
+    last_seen_at: datetime | None = None
+    active_sessions: int
+
+
+class AdminUsersResponse(BaseModel):
+    count: int
+    items: list[AdminUserRecord]
+
+
 class AdminActionTokenResponse(BaseModel):
     token: str
     expires_at: datetime

--- a/services/api/schemas/admin.py
+++ b/services/api/schemas/admin.py
@@ -88,3 +88,26 @@ class AdminAuditLogRecord(BaseModel):
 class AdminAuditLogsResponse(BaseModel):
     count: int
     items: list[AdminAuditLogRecord]
+
+
+class AdminActionTokenResponse(BaseModel):
+    token: str
+    expires_at: datetime
+
+
+class AdminSetAdminRequest(BaseModel):
+    is_admin: bool
+
+
+class AdminUserActionResponse(BaseModel):
+    user_id: UUID
+    email: str
+    username: str
+    is_admin: bool
+    disabled_at: datetime | None = None
+    revoked_sessions: int | None = None
+
+
+class AdminRevokeSessionsResponse(BaseModel):
+    user_id: UUID
+    revoked_count: int

--- a/services/api/schemas/admin.py
+++ b/services/api/schemas/admin.py
@@ -106,6 +106,18 @@ class AdminUsersResponse(BaseModel):
     items: list[AdminUserRecord]
 
 
+class AdminSubmissionControlResponse(BaseModel):
+    manual_closed: bool
+    close_at: datetime | None = None
+    is_closed: bool
+    updated_at: datetime | None = None
+    updated_by: UUID | None = None
+
+
+class AdminSubmissionScheduleRequest(BaseModel):
+    close_at: datetime | None = None
+
+
 class AdminActionTokenResponse(BaseModel):
     token: str
     expires_at: datetime

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -87,8 +87,11 @@ def client(db_session):
 
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app) as c:
-        yield c
+    try:
+        with TestClient(app, client=("127.0.0.1", 50000)) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
 
 
 @pytest.fixture()

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -179,3 +179,8 @@ def fake_redis():
             return deleted
 
     return FakeRedis()
+    try:
+        with TestClient(app, client=("127.0.0.1", 50000)) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -182,8 +182,3 @@ def fake_redis():
             return deleted
 
     return FakeRedis()
-    try:
-        with TestClient(app, client=("127.0.0.1", 50000)) as c:
-            yield c
-    finally:
-        app.dependency_overrides.pop(get_db, None)

--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -1,3 +1,5 @@
+"""Tests for admin endpoints, access controls, and audit logging."""
+
 from __future__ import annotations
 
 import hashlib
@@ -13,6 +15,7 @@ from main import app
 
 
 def _create_user(db_session, *, is_admin: bool) -> str:
+    """Insert a test user and return the user id."""
     suffix = uuid4().hex[:8]
     row = db_session.execute(
         text(
@@ -33,6 +36,7 @@ def _create_user(db_session, *, is_admin: bool) -> str:
 
 
 def _create_session_token(db_session, *, user_id: str) -> str:
+    """Insert a session token for the given user and return the raw token."""
     token = f"admin-test-token-{uuid4()}"
     token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
     now = datetime.now(timezone.utc)
@@ -55,6 +59,7 @@ def _create_session_token(db_session, *, user_id: str) -> str:
 
 
 def _issue_admin_action_token(client, *, access_token: str, origin: str) -> str:
+    """Request an admin action token from the API."""
     resp = client.post(
         "/admin/actions/token",
         headers={"Authorization": f"Bearer {access_token}", "Origin": origin},
@@ -64,6 +69,7 @@ def _issue_admin_action_token(client, *, access_token: str, origin: str) -> str:
 
 
 def _create_submission(db_session, *, user_id: str, submission_type: str) -> str:
+    """Insert a test submission and return the submission id."""
     row = db_session.execute(
         text(
             """
@@ -79,6 +85,7 @@ def _create_submission(db_session, *, user_id: str, submission_type: str) -> str
 
 
 def test_admin_overview_requires_admin_role(client, db_session):
+    """Non-admin users should be blocked from the overview endpoint."""
     user_id = _create_user(db_session, is_admin=False)
     access_token = _create_session_token(db_session, user_id=user_id)
 
@@ -89,6 +96,7 @@ def test_admin_overview_requires_admin_role(client, db_session):
 
 
 def test_admin_overview_requires_localhost(db_session):
+    """Remote clients should be rejected when localhost-only mode is enabled."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
 
@@ -108,6 +116,7 @@ def test_admin_overview_requires_localhost(db_session):
 
 
 def test_admin_overview_rejects_forwarded_remote_client_from_trusted_proxy(db_session):
+    """Reject forwarded remote clients even when the proxy is trusted."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
 
@@ -133,6 +142,7 @@ def test_admin_overview_rejects_forwarded_remote_client_from_trusted_proxy(db_se
 
 
 def test_admin_overview_allows_forwarded_local_client_from_trusted_proxy(db_session):
+    """Allow forwarded localhost clients from trusted proxies."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
 
@@ -157,6 +167,7 @@ def test_admin_overview_allows_forwarded_local_client_from_trusted_proxy(db_sess
 
 
 def test_admin_overview_allows_configured_admin_allowed_hosts(db_session, monkeypatch):
+    """Allow explicit host allowlist entries."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
 
@@ -179,6 +190,7 @@ def test_admin_overview_allows_configured_admin_allowed_hosts(db_session, monkey
 
 
 def test_admin_overview_allows_configured_admin_allowed_networks(db_session, monkeypatch):
+    """Allow explicit network allowlist entries."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
 
@@ -201,6 +213,7 @@ def test_admin_overview_allows_configured_admin_allowed_networks(db_session, mon
 
 
 def test_admin_overview_returns_system_counts_for_local_admin(client, db_session):
+    """Return system counts for authenticated local admins."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
     standard_user_id = _create_user(db_session, is_admin=False)
@@ -260,6 +273,7 @@ def test_admin_overview_returns_system_counts_for_local_admin(client, db_session
 
 
 def test_admin_job_logs_support_filters(client, db_session):
+    """Allow filtering admin job logs by status."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
     now = datetime.now(timezone.utc)
@@ -294,6 +308,7 @@ def test_admin_job_logs_support_filters(client, db_session):
 
 
 def test_admin_action_token_requires_origin(client, db_session):
+    """Enforce origin requirement when issuing admin action tokens."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
 
@@ -304,6 +319,7 @@ def test_admin_action_token_requires_origin(client, db_session):
 
 
 def test_admin_disable_user_requires_action_token(client, db_session):
+    """Disabling a user should require an admin action token."""
     admin_user_id = _create_user(db_session, is_admin=True)
     target_user_id = _create_user(db_session, is_admin=False)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
@@ -348,6 +364,7 @@ def test_admin_disable_user_requires_action_token(client, db_session):
 
 
 def test_admin_users_list_returns_all_users(client, db_session):
+    """List all users, including admin metadata and session counts."""
     admin_user_id = _create_user(db_session, is_admin=True)
     standard_user_id = _create_user(db_session, is_admin=False)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
@@ -363,6 +380,7 @@ def test_admin_users_list_returns_all_users(client, db_session):
 
 
 def test_admin_submission_controls_close_open_and_schedule(client, db_session):
+    """Allow admins to close, open, and schedule submission shutdowns."""
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)
     origin = "http://localhost:14321"

--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -54,6 +54,15 @@ def _create_session_token(db_session, *, user_id: str) -> str:
     return token
 
 
+def _issue_admin_action_token(client, *, access_token: str, origin: str) -> str:
+    resp = client.post(
+        "/admin/actions/token",
+        headers={"Authorization": f"Bearer {access_token}", "Origin": origin},
+    )
+    assert resp.status_code == 200
+    return resp.json()["token"]
+
+
 def _create_submission(db_session, *, user_id: str, submission_type: str) -> str:
     row = db_session.execute(
         text(
@@ -336,3 +345,83 @@ def test_admin_disable_user_requires_action_token(client, db_session):
     )
     assert reused_token_resp.status_code == 403
     assert reused_token_resp.json()["detail"] == "Invalid admin action token"
+
+
+def test_admin_users_list_returns_all_users(client, db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    standard_user_id = _create_user(db_session, is_admin=False)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    resp = client.get("/admin/users", headers={"Authorization": f"Bearer {access_token}"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] >= 2
+    ids = [item["id"] for item in body["items"]]
+    assert admin_user_id in ids
+    assert standard_user_id in ids
+
+
+def test_admin_submission_controls_close_open_and_schedule(client, db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+    origin = "http://localhost:14321"
+
+    status_resp = client.get(
+        "/admin/submissions/status",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert status_resp.status_code == 200
+    assert status_resp.json()["manual_closed"] is False
+
+    close_token = _issue_admin_action_token(client, access_token=access_token, origin=origin)
+    close_resp = client.post(
+        "/admin/submissions/close",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Origin": origin,
+            "X-Admin-Action": close_token,
+        },
+    )
+    assert close_resp.status_code == 200
+    assert close_resp.json()["manual_closed"] is True
+    assert close_resp.json()["is_closed"] is True
+
+    open_token = _issue_admin_action_token(client, access_token=access_token, origin=origin)
+    open_resp = client.post(
+        "/admin/submissions/open",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Origin": origin,
+            "X-Admin-Action": open_token,
+        },
+    )
+    assert open_resp.status_code == 200
+    assert open_resp.json()["manual_closed"] is False
+
+    schedule_token = _issue_admin_action_token(client, access_token=access_token, origin=origin)
+    close_at = datetime.now(timezone.utc) + timedelta(days=1)
+    schedule_resp = client.post(
+        "/admin/submissions/schedule",
+        json={"close_at": close_at.isoformat()},
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Origin": origin,
+            "X-Admin-Action": schedule_token,
+        },
+    )
+    assert schedule_resp.status_code == 200
+    assert schedule_resp.json()["close_at"] is not None
+
+    clear_token = _issue_admin_action_token(client, access_token=access_token, origin=origin)
+    clear_resp = client.post(
+        "/admin/submissions/schedule",
+        json={"close_at": None},
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Origin": origin,
+            "X-Admin-Action": clear_token,
+        },
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["close_at"] is None

--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -282,3 +282,57 @@ def test_admin_job_logs_support_filters(client, db_session):
     assert body["count"] == 1
     assert body["items"][0]["status"] == "failed"
     assert body["items"][0]["job_type"] == "A"
+
+
+def test_admin_action_token_requires_origin(client, db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    resp = client.post("/admin/actions/token", headers={"Authorization": f"Bearer {access_token}"})
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin actions require a localhost browser origin"
+
+
+def test_admin_disable_user_requires_action_token(client, db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    target_user_id = _create_user(db_session, is_admin=False)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+    origin = "http://localhost:14321"
+
+    token_resp = client.post(
+        "/admin/actions/token",
+        headers={"Authorization": f"Bearer {access_token}", "Origin": origin},
+    )
+    assert token_resp.status_code == 200
+    token = token_resp.json()["token"]
+
+    missing_token_resp = client.post(
+        f"/admin/users/{target_user_id}/disable",
+        headers={"Authorization": f"Bearer {access_token}", "Origin": origin},
+    )
+    assert missing_token_resp.status_code == 403
+    assert missing_token_resp.json()["detail"] == "Admin action token required"
+
+    disable_resp = client.post(
+        f"/admin/users/{target_user_id}/disable",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Origin": origin,
+            "X-Admin-Action": token,
+        },
+    )
+    assert disable_resp.status_code == 200
+    assert disable_resp.json()["user_id"] == target_user_id
+    assert disable_resp.json()["disabled_at"] is not None
+
+    reused_token_resp = client.post(
+        f"/admin/users/{target_user_id}/disable",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Origin": origin,
+            "X-Admin-Action": token,
+        },
+    )
+    assert reused_token_resp.status_code == 403
+    assert reused_token_resp.json()["detail"] == "Invalid admin action token"

--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from core.database import get_db
+from core.settings import get_settings
+from main import app
+
+
+def _create_user(db_session, *, is_admin: bool) -> str:
+    suffix = uuid4().hex[:8]
+    row = db_session.execute(
+        text(
+            """
+            INSERT INTO users (username, email, is_admin)
+            VALUES (:username, :email, :is_admin)
+            RETURNING id
+            """
+        ),
+        {
+            "username": f"admin_test_{suffix}",
+            "email": f"admin_test_{suffix}@example.com",
+            "is_admin": is_admin,
+        },
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
+def _create_session_token(db_session, *, user_id: str) -> str:
+    token = f"admin-test-token-{uuid4()}"
+    token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    now = datetime.now(timezone.utc)
+
+    db_session.execute(
+        text(
+            """
+            INSERT INTO user_sessions (user_id, token_hash, expires_at, last_seen_at)
+            VALUES (:user_id, :token_hash, :expires_at, :last_seen_at)
+            """
+        ),
+        {
+            "user_id": user_id,
+            "token_hash": token_hash,
+            "expires_at": now + timedelta(hours=2),
+            "last_seen_at": now,
+        },
+    )
+    return token
+
+
+def _create_submission(db_session, *, user_id: str, submission_type: str) -> str:
+    row = db_session.execute(
+        text(
+            """
+            INSERT INTO submissions (user_id, submission_type, version, status)
+            VALUES (:user_id, :submission_type, '0.0.1', 'submitted')
+            RETURNING id
+            """
+        ),
+        {"user_id": user_id, "submission_type": submission_type},
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
+def test_admin_overview_requires_admin_role(client, db_session):
+    user_id = _create_user(db_session, is_admin=False)
+    access_token = _create_session_token(db_session, user_id=user_id)
+
+    resp = client.get("/admin/overview", headers={"Authorization": f"Bearer {access_token}"})
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin privileges required"
+
+
+def test_admin_overview_requires_localhost(db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app, client=("198.51.100.42", 50000)) as remote_client:
+            resp = remote_client.get("/admin/overview", headers={"Authorization": f"Bearer {access_token}"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin endpoints are only available from localhost"
+
+
+def test_admin_overview_rejects_forwarded_remote_client_from_trusted_proxy(db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app, client=("127.0.0.1", 50000)) as proxied_client:
+            resp = proxied_client.get(
+                "/admin/overview",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "X-Forwarded-For": "198.51.100.17",
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin endpoints are only available from localhost"
+
+
+def test_admin_overview_allows_forwarded_local_client_from_trusted_proxy(db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app, client=("127.0.0.1", 50000)) as proxied_client:
+            resp = proxied_client.get(
+                "/admin/overview",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "X-Forwarded-For": "127.0.0.1",
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+
+
+def test_admin_overview_returns_system_counts_for_local_admin(client, db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+    standard_user_id = _create_user(db_session, is_admin=False)
+    _create_session_token(db_session, user_id=standard_user_id)
+
+    defense_submission_id = _create_submission(db_session, user_id=standard_user_id, submission_type="defense")
+    attack_submission_id = _create_submission(db_session, user_id=standard_user_id, submission_type="attack")
+
+    db_session.execute(
+        text(
+            """
+            INSERT INTO jobs (job_type, status, requested_by_user_id, payload)
+            VALUES
+                ('D', 'queued', :user_id, '{}'::jsonb),
+                ('A', 'running', :user_id, '{}'::jsonb),
+                ('A', 'failed', :user_id, '{}'::jsonb)
+            """
+        ),
+        {"user_id": standard_user_id},
+    )
+    db_session.execute(
+        text(
+            """
+            INSERT INTO evaluation_runs (
+                defense_submission_id,
+                attack_submission_id,
+                scope,
+                status,
+                include_behavior_different,
+                error,
+                duration_ms
+            )
+            VALUES (:defense_submission_id, :attack_submission_id, 'zip', 'failed', false, 'boom', 123)
+            """
+        ),
+        {
+            "defense_submission_id": defense_submission_id,
+            "attack_submission_id": attack_submission_id,
+        },
+    )
+
+    resp = client.get("/admin/overview", headers={"Authorization": f"Bearer {access_token}"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["environment"] == get_settings().env
+    assert body["counts"] == {
+        "users_total": 2,
+        "users_active": 2,
+        "sessions_active": 2,
+        "submissions_total": 2,
+        "evaluation_runs_total": 1,
+        "jobs_queued": 1,
+        "jobs_running": 1,
+        "jobs_failed": 1,
+    }
+
+
+def test_admin_job_logs_support_filters(client, db_session):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+    now = datetime.now(timezone.utc)
+
+    db_session.execute(
+        text(
+            """
+            INSERT INTO jobs (job_type, status, requested_by_user_id, payload, created_at, updated_at)
+            VALUES
+                ('D', 'queued', :user_id, '{"a": 1}'::jsonb, :older, :older),
+                ('A', 'failed', :user_id, '{"a": 2}'::jsonb, :newer, :newer)
+            """
+        ),
+        {
+            "user_id": admin_user_id,
+            "older": now - timedelta(minutes=5),
+            "newer": now,
+        },
+    )
+
+    resp = client.get(
+        "/admin/logs/jobs",
+        params={"status_filter": "failed", "limit": 1},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["items"][0]["status"] == "failed"
+    assert body["items"][0]["job_type"] == "A"

--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -147,6 +147,50 @@ def test_admin_overview_allows_forwarded_local_client_from_trusted_proxy(db_sess
     assert resp.status_code == 200
 
 
+def test_admin_overview_allows_configured_admin_allowed_hosts(db_session, monkeypatch):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    monkeypatch.setenv("ADMIN_ALLOWED_HOSTS", '["203.0.113.10"]')
+    get_settings.cache_clear()
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app, client=("203.0.113.10", 50000)) as remote_client:
+            resp = remote_client.get("/admin/overview", headers={"Authorization": f"Bearer {access_token}"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        get_settings.cache_clear()
+
+    assert resp.status_code == 200
+
+
+def test_admin_overview_allows_configured_admin_allowed_networks(db_session, monkeypatch):
+    admin_user_id = _create_user(db_session, is_admin=True)
+    access_token = _create_session_token(db_session, user_id=admin_user_id)
+
+    monkeypatch.setenv("ADMIN_ALLOWED_NETWORKS", '["203.0.113.0/24"]')
+    get_settings.cache_clear()
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app, client=("203.0.113.77", 50000)) as remote_client:
+            resp = remote_client.get("/admin/overview", headers={"Authorization": f"Bearer {access_token}"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        get_settings.cache_clear()
+
+    assert resp.status_code == 200
+
+
 def test_admin_overview_returns_system_counts_for_local_admin(client, db_session):
     admin_user_id = _create_user(db_session, is_admin=True)
     access_token = _create_session_token(db_session, user_id=admin_user_id)

--- a/services/api/tests/test_router_auth_extra.py
+++ b/services/api/tests/test_router_auth_extra.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import HTTPException, Response
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
+from unittest.mock import MagicMock
 
 from routers import auth as auth_router
 from schemas.auth import RegisterRequest
@@ -113,11 +114,14 @@ class _FakeSession:
 
 def test_register_raises_when_user_row_missing():
     fake_db = _FakeSession(responses=[None, None, None])
+    fake_request = MagicMock()
+    fake_request.client = None
 
     with pytest.raises(HTTPException) as exc:
         auth_router.register(
             RegisterRequest(email="missing@example.com", username="missinguser"),
             Response(),
+            fake_request,
             db=fake_db,
         )
 
@@ -129,11 +133,14 @@ def test_register_rolls_back_on_integrity_error():
         responses=[None, None],
         raise_on={"INSERT INTO users": IntegrityError("stmt", {}, Exception("dup"))},
     )
+    fake_request = MagicMock()
+    fake_request.client = None
 
     with pytest.raises(HTTPException) as exc:
         auth_router.register(
             RegisterRequest(email="dupe@example.com", username="dupeuser"),
             Response(),
+            fake_request,
             db=fake_db,
         )
 
@@ -162,10 +169,13 @@ def test_register_rolls_back_on_http_exception(monkeypatch):
 
     monkeypatch.setattr(auth_router, "create_session", _boom_create_session)
 
+    fake_request = MagicMock()
+    fake_request.client = None
     with pytest.raises(HTTPException) as exc:
         auth_router.register(
             RegisterRequest(email="boom@example.com", username="boomuser"),
             Response(),
+            fake_request,
             db=fake_db,
         )
 

--- a/services/api/tests/test_submissions.py
+++ b/services/api/tests/test_submissions.py
@@ -111,6 +111,7 @@ def _create_password_protected_zip() -> io.BytesIO:
 
 
 def _set_submission_control(db_session, *, manual_closed: bool, close_at: datetime | None) -> None:
+    """Upsert submission control flags for test scenarios."""
     db_session.execute(
         text(
             """

--- a/services/api/tests/test_submissions.py
+++ b/services/api/tests/test_submissions.py
@@ -110,6 +110,21 @@ def _create_password_protected_zip() -> io.BytesIO:
     return zip_buffer
 
 
+def _set_submission_control(db_session, *, manual_closed: bool, close_at: datetime | None) -> None:
+    db_session.execute(
+        text(
+            """
+            INSERT INTO submission_control (id, manual_closed, close_at)
+            VALUES (1, :manual_closed, :close_at)
+            ON CONFLICT (id) DO UPDATE
+            SET manual_closed = EXCLUDED.manual_closed,
+                close_at = EXCLUDED.close_at
+            """
+        ),
+        {"manual_closed": manual_closed, "close_at": close_at},
+    )
+
+
 # ============================================================================
 # Defense Docker Submission Tests
 # ============================================================================
@@ -117,6 +132,55 @@ def _create_password_protected_zip() -> io.BytesIO:
 
 class TestDefenseDockerSubmission:
     """Test Docker Hub defense submission endpoint."""
+
+    def test_submissions_rejected_when_manually_closed(self, client, db_session, monkeypatch):
+        from routers import submissions as submissions_module
+
+        fake = _FakeCelery()
+        monkeypatch.setattr(submissions_module, "_publish_task",
+                            lambda **kwargs: fake.send_task("", kwargs))
+
+        user_id = _create_user(db_session, username="closed_manual_user", email="closed_manual@example.com")
+        token = _create_session_token(db_session, user_id=user_id)
+        _set_submission_control(db_session, manual_closed=True, close_at=None)
+
+        response = client.post(
+            "/api/submissions/defense/docker",
+            json={
+                "docker_image": "nginx:latest",
+                "version": "1.0.0",
+                "display_name": "My Defense",
+            },
+            headers=_make_auth_headers(token),
+        )
+
+        assert response.status_code == 403
+        assert "closed" in response.json()["detail"].lower()
+
+    def test_submissions_rejected_when_deadline_passed(self, client, db_session, monkeypatch):
+        from routers import submissions as submissions_module
+
+        fake = _FakeCelery()
+        monkeypatch.setattr(submissions_module, "_publish_task",
+                            lambda **kwargs: fake.send_task("", kwargs))
+
+        user_id = _create_user(db_session, username="closed_deadline_user", email="closed_deadline@example.com")
+        token = _create_session_token(db_session, user_id=user_id)
+        past_deadline = datetime.now(timezone.utc) - timedelta(minutes=5)
+        _set_submission_control(db_session, manual_closed=False, close_at=past_deadline)
+
+        response = client.post(
+            "/api/submissions/defense/docker",
+            json={
+                "docker_image": "nginx:latest",
+                "version": "1.0.0",
+                "display_name": "My Defense",
+            },
+            headers=_make_auth_headers(token),
+        )
+
+        assert response.status_code == 403
+        assert "closed" in response.json()["detail"].lower()
 
     def test_create_defense_docker_success(self, client, db_session, monkeypatch):
         """Test successful Docker defense submission."""

--- a/services/frontend/astro.config.mjs
+++ b/services/frontend/astro.config.mjs
@@ -12,10 +12,10 @@ export default defineConfig({
   vite: {
     server: {
       proxy: {
-        '/health': 'http://127.0.0.1:8000',
-        '/auth': 'http://127.0.0.1:8000',
-        '/defense': 'http://127.0.0.1:8000',
-        '/api': 'http://127.0.0.1:8000',
+        '/health': process.env.API_PROXY_TARGET ?? 'http://127.0.0.1:8000',
+        '/auth': process.env.API_PROXY_TARGET ?? 'http://127.0.0.1:8000',
+        '/defense': process.env.API_PROXY_TARGET ?? 'http://127.0.0.1:8000',
+        '/api': process.env.API_PROXY_TARGET ?? 'http://127.0.0.1:8000',
       },
     },
   },

--- a/services/frontend/src/lib/auth.ts
+++ b/services/frontend/src/lib/auth.ts
@@ -2,7 +2,11 @@
 export async function getSession(request: Request) {
   const cookie = request.headers.get('cookie') ?? '';
 
-  const res = await fetch(`http://localhost:8000/auth/me`, {
+  const apiBase =
+    import.meta.env.PUBLIC_API_URL?.replace(/\/+$/, '') ??
+    'http://localhost:8000';
+
+  const res = await fetch(`${apiBase}/auth/me`, {
     headers: { cookie }, // forward the browser's cookie to FastAPI
   });
 

--- a/services/postgres/init/database_schema.sql
+++ b/services/postgres/init/database_schema.sql
@@ -83,6 +83,22 @@ CREATE INDEX idx_audit_logs_user_id ON audit_logs(user_id);
 
 
 --------------------------------------------------
+-- SUBMISSION CONTROL
+--------------------------------------------------
+CREATE TABLE IF NOT EXISTS submission_control (
+    id INT PRIMARY KEY CHECK (id = 1),
+    manual_closed BOOLEAN NOT NULL DEFAULT FALSE,
+    close_at TIMESTAMPTZ NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by UUID NULL REFERENCES users(id) ON DELETE SET NULL
+);
+
+INSERT INTO submission_control (id)
+VALUES (1)
+ON CONFLICT (id) DO NOTHING;
+
+
+--------------------------------------------------
 -- SUBMISSIONS
 --------------------------------------------------
 CREATE TABLE IF NOT EXISTS submissions (

--- a/services/postgres/init/database_schema.sql
+++ b/services/postgres/init/database_schema.sql
@@ -49,6 +49,19 @@ CREATE INDEX idx_user_sessions_expires_at ON user_sessions(expires_at);
 
 
 --------------------------------------------------
+-- ADMIN ACTION TOKENS
+--------------------------------------------------
+CREATE TABLE IF NOT EXISTS admin_action_tokens (
+    session_id UUID PRIMARY KEY REFERENCES user_sessions(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_admin_action_tokens_expires_at ON admin_action_tokens(expires_at);
+
+
+--------------------------------------------------
 -- AUDIT LOGS
 --------------------------------------------------
 CREATE TABLE IF NOT EXISTS audit_logs (

--- a/services/postgres/init/database_schema.sql
+++ b/services/postgres/init/database_schema.sql
@@ -49,6 +49,27 @@ CREATE INDEX idx_user_sessions_expires_at ON user_sessions(expires_at);
 
 
 --------------------------------------------------
+-- AUDIT LOGS
+--------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type TEXT NOT NULL,
+    user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+    email TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    success BOOLEAN,
+    message TEXT,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_audit_logs_event_type ON audit_logs(event_type);
+CREATE INDEX idx_audit_logs_created_at ON audit_logs(created_at);
+CREATE INDEX idx_audit_logs_user_id ON audit_logs(user_id);
+
+
+--------------------------------------------------
 -- SUBMISSIONS
 --------------------------------------------------
 CREATE TABLE IF NOT EXISTS submissions (


### PR DESCRIPTION
Admin endpoints are protected by a localhost-only gate: every /admin/* request must originate from loopback (127.0.0.1/::1) unless explicitly allowlisted. The handler resolves the effective client IP (honoring X-Forwarded-For only from trusted proxies), then blocks non-loopback clients with a 403. 

I started to do some local testing. I made Chat create me a small frontend page to see what I could do with the routes. I stashed those changes in this branch so we can come back to it and play with it. But the changes in this PR are purely backend logic. 

Note that this is also my first attempt at this kind of logic so it might have some security things I overlooked. Maxim feel free to branch off this branch to see if you can implement the frontend and maybe we can start building up better routes for you to use. The ones I made are extremely general so they might be difficult to work with, but that's something that can be easily changed. 