### PR TITLE
Submission History API (Defense/Attack) 

### DIFF
--- a/services/api/routers/submissions.py
+++ b/services/api/routers/submissions.py
@@ -399,6 +399,26 @@ def defense_submission_history(
     )
 
 
+@router.get(
+    "/attack/history",
+    response_model=SubmissionHistoryResponse,
+)
+def attack_submission_history(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: AuthenticatedUser = Depends(get_authenticated_user),
+    db: Session = Depends(get_db),
+) -> SubmissionHistoryResponse:
+    """Return the authenticated user's attack submission history."""
+    return _get_submission_history(
+        db=db,
+        user_id=str(current_user.user_id),
+        submission_type="attack",
+        limit=limit,
+        offset=offset,
+    )
+
+
 @router.post(
     "/attack/zip",
     response_model=SubmissionResponse,

--- a/services/api/routers/submissions.py
+++ b/services/api/routers/submissions.py
@@ -8,7 +8,7 @@ import zipfile
 from datetime import datetime
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -28,11 +28,62 @@ from schemas.jobs import JobType
 from schemas.submissions import (
     CreateDefenseDockerRequest,
     CreateDefenseGitHubRequest,
+    SubmissionHistoryResponse,
     SubmissionResponse,
 )
 
 router = APIRouter(prefix="/submissions", tags=["submissions"])
 logger = logging.getLogger(__name__)
+
+
+def _get_submission_history(
+    *,
+    db: Session,
+    user_id: str,
+    submission_type: str,
+    limit: int,
+    offset: int,
+) -> SubmissionHistoryResponse:
+    base_sql = """
+        FROM submissions s
+        WHERE s.user_id = :user_id
+          AND s.submission_type = :submission_type
+          AND s.deleted_at IS NULL
+    """
+
+    data_sql = f"""
+        SELECT
+            s.id AS submission_id,
+            s.submission_type AS submission_type,
+            s.status AS status,
+            s.version AS version,
+            s.display_name AS display_name,
+            s.created_at AS created_at
+        {base_sql}
+        ORDER BY s.created_at DESC
+        LIMIT :limit OFFSET :offset
+    """
+
+    count_sql = f"""
+        SELECT COUNT(*)
+        {base_sql}
+    """
+
+    params = {"user_id": user_id, "submission_type": submission_type}
+    rows = db.execute(
+        text(data_sql),
+        {**params, "limit": limit, "offset": offset},
+    ).mappings().fetchall()
+
+    total = db.execute(text(count_sql), params).scalar() or 0
+    items = [dict(row) for row in rows]
+
+    return SubmissionHistoryResponse(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.post(
@@ -325,6 +376,26 @@ async def create_defense_zip(
         display_name=display_name,
         created_at=created_at.isoformat() if created_at else datetime.utcnow().isoformat(),
         job_id=str(job_id),
+    )
+
+
+@router.get(
+    "/defense/history",
+    response_model=SubmissionHistoryResponse,
+)
+def defense_submission_history(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: AuthenticatedUser = Depends(get_authenticated_user),
+    db: Session = Depends(get_db),
+) -> SubmissionHistoryResponse:
+    """Return the authenticated user's defense submission history."""
+    return _get_submission_history(
+        db=db,
+        user_id=str(current_user.user_id),
+        submission_type="defense",
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/services/api/schemas/submissions.py
+++ b/services/api/schemas/submissions.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from uuid import UUID
+
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -67,3 +70,23 @@ class SubmissionDetailsResponse(BaseModel):
     user_id: str
     # Nested details added dynamically based on type
     details: dict
+
+
+class SubmissionHistoryItem(BaseModel):
+    """History item for a user's submissions."""
+
+    submission_id: UUID
+    submission_type: str
+    status: str
+    version: str
+    display_name: str | None
+    created_at: datetime
+
+
+class SubmissionHistoryResponse(BaseModel):
+    """Paginated submission history response."""
+
+    items: list[SubmissionHistoryItem]
+    total: int
+    limit: int
+    offset: int

--- a/services/api/tests/test_submissions.py
+++ b/services/api/tests/test_submissions.py
@@ -37,16 +37,22 @@ class _FakeCelery:
         return _FakeAsyncResult("test-task-id")
 
 
-def _create_user(db_session) -> str:
+def _create_user(
+    db_session,
+    *,
+    username: str = "test_submission_user",
+    email: str = "test_submission@email.com",
+) -> str:
     """Create test user and return user_id."""
     row = db_session.execute(
         text(
             """
             INSERT INTO users (username, email, is_admin)
-            VALUES ('test_submission_user', 'test_submission@email.com', false)
+            VALUES (:username, :email, false)
             RETURNING id
             """
-        )
+        ),
+        {"username": username, "email": email},
     ).fetchone()
     assert row is not None
     return str(row[0])
@@ -559,3 +565,142 @@ class TestValidationHelpers:
         with pytest.raises(HTTPException) as exc:
             validate_docker_image_format("-invalid")
         assert exc.value.status_code == 400
+
+
+# ============================================================================
+# Submission History Tests
+# ============================================================================
+
+
+class TestDefenseSubmissionHistory:
+    """Test defense submission history endpoint."""
+
+    def test_history_requires_auth(self, client):
+        response = client.get("/api/submissions/defense/history")
+        assert response.status_code == 401
+
+    def test_history_returns_only_user_defense(self, client, db_session):
+        user_id = _create_user(db_session)
+        token = _create_session_token(db_session, user_id=user_id)
+
+        other_user_id = _create_user(
+            db_session,
+            username="other_submission_user",
+            email="other_submission@email.com",
+        )
+
+        now = datetime.now(timezone.utc)
+        older = now - timedelta(hours=1)
+
+        defense_new = str(uuid4())
+        defense_old = str(uuid4())
+        defense_deleted = str(uuid4())
+        attack_submission = str(uuid4())
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": defense_old,
+                "user_id": user_id,
+                "submission_type": "defense",
+                "version": "1.0.0",
+                "display_name": "Old Defense",
+                "status": "submitted",
+                "created_at": older,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": defense_new,
+                "user_id": user_id,
+                "submission_type": "defense",
+                "version": "1.1.0",
+                "display_name": "New Defense",
+                "status": "ready",
+                "created_at": now,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at, deleted_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at, :deleted_at)
+                """
+            ),
+            {
+                "id": defense_deleted,
+                "user_id": user_id,
+                "submission_type": "defense",
+                "version": "9.9.9",
+                "display_name": "Deleted Defense",
+                "status": "failed",
+                "created_at": now,
+                "deleted_at": now,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": attack_submission,
+                "user_id": user_id,
+                "submission_type": "attack",
+                "version": "0.0.1",
+                "display_name": "Attack",
+                "status": "submitted",
+                "created_at": now,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": str(uuid4()),
+                "user_id": other_user_id,
+                "submission_type": "defense",
+                "version": "2.0.0",
+                "display_name": "Other Defense",
+                "status": "submitted",
+                "created_at": now,
+            },
+        )
+
+        response = client.get(
+            "/api/submissions/defense/history",
+            headers=_make_auth_headers(token),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total"] == 2
+        assert payload["limit"] == 50
+        assert payload["offset"] == 0
+
+        items = payload["items"]
+        assert len(items) == 2
+        assert items[0]["submission_id"] == defense_new
+        assert items[1]["submission_id"] == defense_old
+        assert all(item["submission_type"] == "defense" for item in items)

--- a/services/api/tests/test_submissions.py
+++ b/services/api/tests/test_submissions.py
@@ -704,3 +704,137 @@ class TestDefenseSubmissionHistory:
         assert items[0]["submission_id"] == defense_new
         assert items[1]["submission_id"] == defense_old
         assert all(item["submission_type"] == "defense" for item in items)
+
+
+class TestAttackSubmissionHistory:
+    """Test attack submission history endpoint."""
+
+    def test_history_requires_auth(self, client):
+        response = client.get("/api/submissions/attack/history")
+        assert response.status_code == 401
+
+    def test_history_returns_only_user_attack(self, client, db_session):
+        user_id = _create_user(db_session)
+        token = _create_session_token(db_session, user_id=user_id)
+
+        other_user_id = _create_user(
+            db_session,
+            username="other_attack_user",
+            email="other_attack@email.com",
+        )
+
+        now = datetime.now(timezone.utc)
+        older = now - timedelta(hours=2)
+
+        attack_new = str(uuid4())
+        attack_old = str(uuid4())
+        attack_deleted = str(uuid4())
+        defense_submission = str(uuid4())
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": attack_old,
+                "user_id": user_id,
+                "submission_type": "attack",
+                "version": "0.1.0",
+                "display_name": "Old Attack",
+                "status": "submitted",
+                "created_at": older,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": attack_new,
+                "user_id": user_id,
+                "submission_type": "attack",
+                "version": "0.2.0",
+                "display_name": "New Attack",
+                "status": "ready",
+                "created_at": now,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at, deleted_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at, :deleted_at)
+                """
+            ),
+            {
+                "id": attack_deleted,
+                "user_id": user_id,
+                "submission_type": "attack",
+                "version": "9.9.9",
+                "display_name": "Deleted Attack",
+                "status": "failed",
+                "created_at": now,
+                "deleted_at": now,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": defense_submission,
+                "user_id": user_id,
+                "submission_type": "defense",
+                "version": "1.0.0",
+                "display_name": "Defense",
+                "status": "submitted",
+                "created_at": now,
+            },
+        )
+
+        db_session.execute(
+            text(
+                """
+                INSERT INTO submissions (id, user_id, submission_type, version, display_name, status, created_at)
+                VALUES (:id, :user_id, :submission_type, :version, :display_name, :status, :created_at)
+                """
+            ),
+            {
+                "id": str(uuid4()),
+                "user_id": other_user_id,
+                "submission_type": "attack",
+                "version": "3.0.0",
+                "display_name": "Other Attack",
+                "status": "submitted",
+                "created_at": now,
+            },
+        )
+
+        response = client.get(
+            "/api/submissions/attack/history",
+            headers=_make_auth_headers(token),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total"] == 2
+        assert payload["limit"] == 50
+        assert payload["offset"] == 0
+
+        items = payload["items"]
+        assert len(items) == 2
+        assert items[0]["submission_id"] == attack_new
+        assert items[1]["submission_id"] == attack_old
+        assert all(item["submission_type"] == "attack" for item in items)


### PR DESCRIPTION
In this PR I threw together the endpoints for attack and defense submission history. They're all from the one table obviously but I assumed you would want two separate endpoints that way you don't have to sort through the info. Also you need to be authenticated to pull from these endpoints just remember that when testing/implementing. 


Added endpoints: 
- `GET /api/submissions/defense/history` 
- `GET /api/submissions/attack/history`