### PR TITLE
Join Code initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
+# docker tmp
+.docker-tmp/
+
 # jetbrains setting folder
 .idea/
 

--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,7 @@ worker:
     template_path: "/app/attack-template"
     max_zip_size_mb: 100
     sandbox_backend: "virustotal"    # "virustotal" | "local"
+
+
+application: 
+  login_code: 'ABC'

--- a/services/api/core/config.py
+++ b/services/api/core/config.py
@@ -22,8 +22,13 @@ class MinIOConfig(BaseModel):
     secure: bool = False
 
 
+class ApplicationConfig(BaseModel):
+    join_code: str | None = None
+
+
 class AppConfig(BaseModel):
     minio: MinIOConfig = Field(default_factory=MinIOConfig)
+    application: ApplicationConfig = Field(default_factory=ApplicationConfig)
 
 
 @lru_cache(maxsize=1)
@@ -38,7 +43,14 @@ def get_config() -> AppConfig:
         with open(config_path) as f:
             data = yaml.safe_load(f) or {}
         minio_data = data.get("worker", {}).get("minio", {})
-        return AppConfig(minio=MinIOConfig(**minio_data))
+        app_data = data.get("application", {}) or {}
+        join_code = app_data.get("join_code")
+        if join_code is None:
+            join_code = app_data.get("login_code")
+        return AppConfig(
+            minio=MinIOConfig(**minio_data),
+            application=ApplicationConfig(join_code=join_code),
+        )
     except Exception as e:
         logger.error(
             f"Failed to load config from {config_path}: {e}. Falling back to defaults.")

--- a/services/api/routers/auth.py
+++ b/services/api/routers/auth.py
@@ -14,11 +14,15 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from core.auth import AuthenticatedUser, create_session, get_authenticated_user, revoke_session_by_id
+from core.config import get_config
 from core.database import get_db
 from core.settings import get_settings
 from schemas.auth import (
+    JOIN_CODE_FIELD,
     REQUIRED_REGISTRATION_FIELDS,
     AuthenticatedUserResponse,
+    JoinCodeValidationRequest,
+    JoinCodeValidationResponse,
     LoginRequest,
     LoginResponse,
     RegisterRequest,
@@ -76,6 +80,37 @@ def _clear_session_cookie(response: Response) -> None:
     )
 
 
+def _normalize_join_code(value: str | None) -> str | None:
+    """Normalize join code input for comparison."""
+    if value is None:
+        return None
+    code = value.strip()
+    return code or None
+
+
+def _configured_join_code() -> str | None:
+    """Return the configured join code, if set."""
+    config = get_config()
+    return _normalize_join_code(config.application.join_code)
+
+
+def _join_code_required() -> bool:
+    """Return True when a join code is configured."""
+    return _configured_join_code() is not None
+
+
+def _validate_join_code_or_raise(submitted_code: str | None) -> None:
+    """Validate the provided join code against configuration."""
+    required_code = _configured_join_code()
+    if required_code is None:
+        return
+    candidate = _normalize_join_code(submitted_code)
+    if not candidate:
+        raise HTTPException(status_code=403, detail="Join code is required")
+    if candidate != required_code:
+        raise HTTPException(status_code=403, detail="Invalid join code")
+
+
 @router.post("/login", response_model=LoginResponse)
 def login(
     req: LoginRequest,
@@ -115,10 +150,13 @@ def login(
         if disabled is not None:
             raise HTTPException(status_code=403, detail="User account is disabled")
 
+        required_fields = list(REQUIRED_REGISTRATION_FIELDS)
+        if _join_code_required():
+            required_fields.append(JOIN_CODE_FIELD)
         return LoginResponse(
             authenticated=False,
             requires_registration=True,
-            required_registration_fields=REQUIRED_REGISTRATION_FIELDS,
+            required_registration_fields=required_fields,
         )
 
     session_token = create_session(db, user_id=row["id"])
@@ -144,6 +182,7 @@ def register(
     db: Session = Depends(get_db),
 ) -> SessionResponse:
     """Register a new user and issue a session token."""
+    _validate_join_code_or_raise(req.join_code)
     existing_email = (
         db.execute(
             text(
@@ -230,6 +269,20 @@ def register(
             is_admin=user_row["is_admin"],
         ),
     )
+
+
+@router.post("/join-code/validate", response_model=JoinCodeValidationResponse)
+def validate_join_code(req: JoinCodeValidationRequest) -> JoinCodeValidationResponse:
+    """Validate a join code against the configured application setting."""
+    required_code = _configured_join_code()
+    if required_code is None:
+        return JoinCodeValidationResponse(valid=True, required=False)
+    candidate = _normalize_join_code(req.join_code)
+    if not candidate:
+        raise HTTPException(status_code=403, detail="Join code is required")
+    if candidate != required_code:
+        raise HTTPException(status_code=403, detail="Invalid join code")
+    return JoinCodeValidationResponse(valid=True, required=True)
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)

--- a/services/api/schemas/auth.py
+++ b/services/api/schemas/auth.py
@@ -13,6 +13,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 REQUIRED_REGISTRATION_FIELDS = ["username"]
+JOIN_CODE_FIELD = "join_code"
 
 _USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{3,32}$")
 
@@ -57,6 +58,7 @@ class RegisterRequest(BaseModel):
 
     email: str = Field(..., min_length=3, max_length=255)
     username: str = Field(..., min_length=3, max_length=32)
+    join_code: str | None = Field(default=None, min_length=1, max_length=128)
 
     @field_validator("email")
     @classmethod
@@ -69,6 +71,35 @@ class RegisterRequest(BaseModel):
     def validate_username(cls, value: str) -> str:
         """Normalize and validate the username field."""
         return _normalize_username(value)
+
+    @field_validator("join_code")
+    @classmethod
+    def normalize_join_code(cls, value: str | None) -> str | None:
+        """Normalize the join code if provided."""
+        if value is None:
+            return None
+        return value.strip()
+
+
+class JoinCodeValidationRequest(BaseModel):
+    """Join code validation request payload."""
+    model_config = ConfigDict(extra="forbid")
+
+    join_code: str | None = Field(default=None, min_length=1, max_length=128)
+
+    @field_validator("join_code")
+    @classmethod
+    def normalize_join_code(cls, value: str | None) -> str | None:
+        """Normalize the join code if provided."""
+        if value is None:
+            return None
+        return value.strip()
+
+
+class JoinCodeValidationResponse(BaseModel):
+    """Join code validation response payload."""
+    valid: bool
+    required: bool
 
 
 class AuthenticatedUserResponse(BaseModel):


### PR DESCRIPTION
Added `POST /auth/join-code/validate` to validate a submitted join code against the configured value, returning valid plus whether a code is required. Returns 403 with Join code is required or Invalid join code when applicable.

I added an "application" section to the config.yaml which the join code is stored and read from that. This is following the idea that the platform owner can create a short join code for the competition before build so only students who know the code can join. 