### PR TITLE
New routes for admin page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,10 @@ worker:
     cleanup_built_images: true            # Remove built images after evaluation (GitHub/ZIP sources only)
   minio:
     bucket_name: "mlsec-submissions"
+    endpoint: "minio:9000"
+    access_key: "mlsec_minio_admin"
+    secret_key: "mlsec_minio_password_change_in_production"
+    secure: false
   attack:
     check_similarity: true           # false = skip evaluation, accept all validated attacks
     reject_dissimilar_attacks: true  # only applies when check_similarity=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
       DATABASE_URL: postgresql://postgres:password123@postgres:5432/mlsec
       CELERY_BROKER_URL: amqp://mlsec:mlsec@rabbitmq:5672//
       REDIS_URL: redis://redis:6379/0
-      ADMIN_ALLOWED_HOSTS: '["172.22.0.1"]' # Docker bridge gateway for localhost SSH tunnel access
+      ADMIN_ALLOWED_HOSTS: '["172.21.0.1","172.22.0.1"]' # Docker bridge gateway for localhost SSH tunnel access
     ports:
       - "8000:8000"
     volumes:

--- a/services/api/core/storage.py
+++ b/services/api/core/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from datetime import datetime
 from functools import lru_cache
 from typing import BinaryIO
 
@@ -160,6 +161,97 @@ def upload_attack_zip(
         "object_key": object_key,
         "sha256": sha256_hash,
         "size_bytes": size_bytes,
+    }
+
+
+def _admin_asset_object_key(asset_type: str) -> str:
+    return f"admin/{asset_type}/latest.zip"
+
+
+def upload_admin_asset(
+    content: bytes,
+    *,
+    asset_type: str,
+    metadata: dict[str, str | None],
+) -> dict[str, str | int]:
+    """
+    Upload admin-managed assets (attack template, defense validation set) to MinIO.
+
+    Args:
+        content: Raw file bytes to upload
+        asset_type: "attack_template" | "defense_validation_set"
+
+    Returns:
+        dict with keys: object_key (str), sha256 (str), size_bytes (int)
+    """
+    client = get_minio_client()
+    bucket_name = get_config().minio.bucket_name
+
+    object_key = _admin_asset_object_key(asset_type)
+
+    hasher = hashlib.sha256()
+    hasher.update(content)
+    sha256_hash = hasher.hexdigest()
+    size_bytes = len(content)
+
+    # Ensure sha256 metadata is present.
+    if metadata.get("sha256") is None:
+        metadata["sha256"] = sha256_hash
+
+    from io import BytesIO
+
+    file_stream = BytesIO(content)
+
+    try:
+        logger.info(
+            "Uploading admin asset to MinIO: %s (%s bytes)", object_key, size_bytes
+        )
+        client.put_object(
+            bucket_name=bucket_name,
+            object_name=object_key,
+            data=file_stream,
+            length=size_bytes,
+            content_type="application/zip",
+            metadata={k: v for k, v in metadata.items() if v is not None},
+        )
+        logger.info(
+            "Successfully uploaded %s (SHA256: %s...)", object_key, sha256_hash[:16]
+        )
+    except S3Error as e:
+        logger.error("Failed to upload %s: %s", object_key, e)
+        raise
+
+    return {
+        "object_key": object_key,
+        "sha256": sha256_hash,
+        "size_bytes": size_bytes,
+    }
+
+
+def stat_admin_asset(asset_type: str) -> dict:
+    """Fetch metadata for the latest admin asset stored at the fixed key."""
+    client = get_minio_client()
+    bucket_name = get_config().minio.bucket_name
+    object_key = _admin_asset_object_key(asset_type)
+
+    stat = client.stat_object(bucket_name, object_key)
+    metadata = stat.metadata or {}
+    uploaded_at = metadata.get("uploaded_at")
+
+    parsed_uploaded_at = None
+    if uploaded_at:
+        try:
+            parsed_uploaded_at = datetime.fromisoformat(uploaded_at)
+        except Exception:
+            parsed_uploaded_at = None
+
+    return {
+        "object_key": object_key,
+        "size_bytes": stat.size,
+        "etag": stat.etag,
+        "metadata": metadata,
+        "last_modified": stat.last_modified,
+        "uploaded_at": parsed_uploaded_at,
     }
 
 

--- a/services/api/routers/admin.py
+++ b/services/api/routers/admin.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
+from minio.error import S3Error
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -18,7 +19,10 @@ from core.admin import (
 from core.audit import log_audit_event
 from core.auth import AuthenticatedUser
 from core.database import get_db
+from core.redis_client import WorkerRegistry
 from core.settings import get_settings
+from core.storage import delete_object, stat_admin_asset, upload_admin_asset
+from core.submissions import require_submission_of_type, validate_file_size
 from core.submission_control import get_submission_control, set_close_at, set_manual_closed
 from schemas.admin import (
     AdminActiveSessionRecord,
@@ -26,19 +30,30 @@ from schemas.admin import (
     AdminActionTokenResponse,
     AdminAuditLogRecord,
     AdminAuditLogsResponse,
+    AdminAssetsResponse,
+    AdminAssetRecord,
     AdminEvaluationLogRecord,
     AdminEvaluationLogsResponse,
+    AdminDefenseEvaluationsResponse,
+    AdminAttackEvaluationsResponse,
     AdminJobLogRecord,
     AdminJobLogsResponse,
     AdminOverviewResponse,
     AdminRevokeSessionsResponse,
     AdminSetAdminRequest,
+    AdminSubmissionRecord,
+    AdminSubmissionLogRecord,
+    AdminSubmissionLogsResponse,
     AdminSubmissionControlResponse,
     AdminSubmissionScheduleRequest,
     AdminSystemCounts,
+    AdminUserDeleteResponse,
     AdminUserRecord,
     AdminUserActionResponse,
+    AdminUserSubmissionsResponse,
     AdminUsersResponse,
+    AdminWorkersResponse,
+    AdminWorkerRecord,
 )
 
 router = APIRouter(
@@ -53,6 +68,61 @@ def _request_meta(request: Request) -> tuple[str | None, str | None]:
     client_ip = request.client.host if request.client else None
     user_agent = request.headers.get("user-agent")
     return client_ip, user_agent
+
+
+def _normalize_asset_type(asset_type: str) -> str:
+    normalized = asset_type.strip().lower().replace("_", "-")
+    mapping = {
+        "attack-template": "attack_template",
+        "defense-validation-set": "defense_validation_set",
+        "attack_template": "attack_template",
+        "defense_validation_set": "defense_validation_set",
+    }
+    if normalized not in mapping:
+        raise HTTPException(status_code=404, detail="Unknown asset type")
+    return mapping[normalized]
+
+
+def _epoch_to_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except Exception:
+        return None
+
+
+def _metadata_uuid(value: str | None) -> UUID | None:
+    if not value:
+        return None
+    try:
+        return UUID(value)
+    except Exception:
+        return None
+
+
+def _is_missing_minio_object(exc: S3Error) -> bool:
+    return exc.code in {"NoSuchKey", "NoSuchObject"}
+
+
+def _derive_worker_task(
+    *,
+    submission_status: str | None,
+    is_functional: bool | None,
+    queue_state: str | None,
+    job_status: str | None,
+) -> str | None:
+    if submission_status == "failed" or is_functional is False:
+        return "Defense validation failed"
+    if is_functional is None:
+        return "Defense functional validation"
+    if queue_state == "OPEN":
+        return "Evaluation"
+    if queue_state == "CLOSED":
+        return "Evaluation idle"
+    if job_status == "running":
+        return "Defense job running"
+    return None
 
 
 def _log_admin_action_failure(
@@ -130,9 +200,22 @@ def get_users(
     offset: int = Query(default=0, ge=0),
     search: str | None = Query(default=None),
     include_disabled: bool = Query(default=True),
+    sort_by: str = Query(default="created_at"),
+    sort_dir: str = Query(default="desc"),
 ) -> AdminUsersResponse:
     """List users with last-seen and active session counts."""
     search_like = f"%{search}%" if search else None
+    sort_columns = {
+        "created_at": "u.created_at",
+        "username": "u.username",
+        "email": "u.email",
+        "is_admin": "u.is_admin",
+        "last_seen": "last_seen.last_seen_at",
+        "active_sessions": "active_sessions.active_count",
+        "disabled_at": "u.disabled_at",
+    }
+    order_column = sort_columns.get(sort_by, "u.created_at")
+    order_dir = "ASC" if sort_dir.lower() == "asc" else "DESC"
     # LATERAL joins let us compute per-user aggregates without duplicating rows.
     rows = (
         db.execute(
@@ -152,8 +235,6 @@ def get_users(
                     SELECT COALESCE(us.last_seen_at, us.created_at) AS last_seen_at
                     FROM user_sessions us
                     WHERE us.user_id = u.id
-                      AND us.revoked_at IS NULL
-                      AND us.expires_at > NOW()
                     ORDER BY COALESCE(us.last_seen_at, us.created_at) DESC
                     LIMIT 1
                 ) last_seen ON TRUE
@@ -166,7 +247,10 @@ def get_users(
                 ) active_sessions ON TRUE
                 WHERE (:search IS NULL OR u.email ILIKE :search_like OR u.username ILIKE :search_like)
                   AND (:include_disabled OR u.disabled_at IS NULL)
-                ORDER BY u.created_at DESC
+                ORDER BY """
+                + order_column
+                + f" {order_dir} NULLS LAST"
+                + """
                 LIMIT :limit
                 OFFSET :offset
                 """
@@ -185,6 +269,61 @@ def get_users(
 
     items = [AdminUserRecord(**row) for row in rows]
     return AdminUsersResponse(count=len(items), items=items)
+
+
+@router.get("/users/{user_id}/submissions", response_model=AdminUserSubmissionsResponse)
+def get_user_submissions(
+    user_id: UUID,
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=200, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    submission_type: str | None = Query(default=None),
+    include_deleted: bool = Query(default=False),
+) -> AdminUserSubmissionsResponse:
+    """Return all submissions for a specific user."""
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    s.id AS submission_id,
+                    s.user_id,
+                    u.username,
+                    u.email,
+                    s.submission_type,
+                    s.status,
+                    s.version,
+                    s.display_name,
+                    s.is_functional,
+                    s.functional_error,
+                    s.created_at,
+                    s.deleted_at
+                FROM submissions s
+                JOIN users u
+                  ON u.id = s.user_id
+                WHERE s.user_id = :user_id
+                  AND (:submission_type IS NULL OR s.submission_type = :submission_type)
+                  AND (:include_deleted OR s.deleted_at IS NULL)
+                ORDER BY s.created_at DESC
+                LIMIT :limit
+                OFFSET :offset
+                """
+            ),
+            {
+                "user_id": str(user_id),
+                "submission_type": submission_type,
+                "include_deleted": include_deleted,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminSubmissionRecord(**row) for row in rows]
+    return AdminUserSubmissionsResponse(count=len(items), items=items)
 
 
 def _submission_control_response(
@@ -409,12 +548,155 @@ def schedule_submissions_close(
         raise
 
 
+@router.get(
+    "/submissions/defense/{defense_id}/attacks",
+    response_model=AdminDefenseEvaluationsResponse,
+)
+def get_defense_attack_evaluations(
+    defense_id: UUID,
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=200, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> AdminDefenseEvaluationsResponse:
+    """List attack submissions with evaluation status for a defense submission."""
+    require_submission_of_type(
+        db, submission_id=defense_id, expected_type="defense"
+    )
+
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    s.id AS attack_submission_id,
+                    s.user_id AS attack_user_id,
+                    u.username AS attack_username,
+                    u.email AS attack_email,
+                    s.status AS attack_status,
+                    s.version AS attack_version,
+                    s.display_name AS attack_display_name,
+                    s.created_at AS attack_created_at,
+                    ev.id AS evaluation_run_id,
+                    ev.status AS evaluation_status,
+                    ev.error AS evaluation_error,
+                    ev.updated_at AS evaluation_updated_at
+                FROM submissions s
+                JOIN users u
+                  ON u.id = s.user_id
+                LEFT JOIN LATERAL (
+                    SELECT id, status, error, updated_at, created_at
+                    FROM evaluation_runs er
+                    WHERE er.defense_submission_id = :defense_id
+                      AND er.attack_submission_id = s.id
+                    ORDER BY er.updated_at DESC NULLS LAST, er.created_at DESC
+                    LIMIT 1
+                ) ev ON TRUE
+                WHERE s.submission_type = 'attack'
+                  AND s.deleted_at IS NULL
+                ORDER BY s.created_at DESC
+                LIMIT :limit
+                OFFSET :offset
+                """
+            ),
+            {
+                "defense_id": str(defense_id),
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        .mappings()
+        .all()
+    )
+
+    items = []
+    for row in rows:
+        record = dict(row)
+        if record.get("evaluation_status") is None:
+            record["evaluation_status"] = "not_started"
+        items.append(record)
+
+    return AdminDefenseEvaluationsResponse(count=len(items), items=items)
+
+
+@router.get(
+    "/submissions/attack/{attack_id}/defenses",
+    response_model=AdminAttackEvaluationsResponse,
+)
+def get_attack_defense_evaluations(
+    attack_id: UUID,
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=200, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> AdminAttackEvaluationsResponse:
+    """List defense submissions with evaluation status for an attack submission."""
+    require_submission_of_type(
+        db, submission_id=attack_id, expected_type="attack"
+    )
+
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    s.id AS defense_submission_id,
+                    s.user_id AS defense_user_id,
+                    u.username AS defense_username,
+                    u.email AS defense_email,
+                    s.status AS defense_status,
+                    s.version AS defense_version,
+                    s.display_name AS defense_display_name,
+                    s.created_at AS defense_created_at,
+                    ev.id AS evaluation_run_id,
+                    ev.status AS evaluation_status,
+                    ev.error AS evaluation_error,
+                    ev.updated_at AS evaluation_updated_at
+                FROM submissions s
+                JOIN users u
+                  ON u.id = s.user_id
+                LEFT JOIN LATERAL (
+                    SELECT id, status, error, updated_at, created_at
+                    FROM evaluation_runs er
+                    WHERE er.defense_submission_id = s.id
+                      AND er.attack_submission_id = :attack_id
+                    ORDER BY er.updated_at DESC NULLS LAST, er.created_at DESC
+                    LIMIT 1
+                ) ev ON TRUE
+                WHERE s.submission_type = 'defense'
+                  AND s.deleted_at IS NULL
+                ORDER BY s.created_at DESC
+                LIMIT :limit
+                OFFSET :offset
+                """
+            ),
+            {
+                "attack_id": str(attack_id),
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        .mappings()
+        .all()
+    )
+
+    items = []
+    for row in rows:
+        record = dict(row)
+        if record.get("evaluation_status") is None:
+            record["evaluation_status"] = "not_started"
+        items.append(record)
+
+    return AdminAttackEvaluationsResponse(count=len(items), items=items)
+
+
 @router.get("/logs/jobs", response_model=AdminJobLogsResponse)
 def get_recent_jobs(
     _: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
     limit: int = Query(default=50, ge=1, le=200),
     status_filter: str | None = Query(default=None),
+    user_id: UUID | None = Query(default=None),
 ) -> AdminJobLogsResponse:
     """Return recent job records for the admin logs view."""
     rows = (
@@ -431,11 +713,16 @@ def get_recent_jobs(
                     updated_at
                 FROM jobs
                 WHERE (:status_filter IS NULL OR status = :status_filter)
+                  AND (:user_id IS NULL OR requested_by_user_id = :user_id)
                 ORDER BY created_at DESC
                 LIMIT :limit
                 """
             ),
-            {"status_filter": status_filter, "limit": limit},
+            {
+                "status_filter": status_filter,
+                "user_id": str(user_id) if user_id else None,
+                "limit": limit,
+            },
         )
         .mappings()
         .all()
@@ -445,12 +732,73 @@ def get_recent_jobs(
     return AdminJobLogsResponse(count=len(items), items=items)
 
 
+@router.get("/logs/submissions", response_model=AdminSubmissionLogsResponse)
+def get_submission_logs(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(default=50, ge=1, le=200),
+    submission_type: str | None = Query(default=None),
+    status_filter: str | None = Query(default=None),
+    user_id: UUID | None = Query(default=None),
+    search: str | None = Query(default=None),
+) -> AdminSubmissionLogsResponse:
+    """Return recent submission events for the admin logs view."""
+    search_like = f"%{search}%" if search else None
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                    s.id AS submission_id,
+                    s.user_id,
+                    u.username,
+                    u.email,
+                    s.submission_type,
+                    s.status,
+                    s.version,
+                    s.display_name,
+                    s.functional_error,
+                    s.created_at
+                FROM submissions s
+                JOIN users u
+                  ON u.id = s.user_id
+                WHERE (:submission_type IS NULL OR s.submission_type = :submission_type)
+                  AND (:status_filter IS NULL OR s.status = :status_filter)
+                  AND (:user_id IS NULL OR s.user_id = :user_id)
+                  AND (
+                      :search IS NULL
+                      OR u.username ILIKE :search_like
+                      OR u.email ILIKE :search_like
+                  )
+                ORDER BY s.created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {
+                "submission_type": submission_type,
+                "status_filter": status_filter,
+                "user_id": str(user_id) if user_id else None,
+                "search": search,
+                "search_like": search_like,
+                "limit": limit,
+            },
+        )
+        .mappings()
+        .all()
+    )
+
+    items = [AdminSubmissionLogRecord(**row) for row in rows]
+    return AdminSubmissionLogsResponse(count=len(items), items=items)
+
+
 @router.get("/logs/evaluations", response_model=AdminEvaluationLogsResponse)
 def get_recent_evaluations(
     _: AuthenticatedUser = Depends(require_admin_user),
     db: Session = Depends(get_db),
     limit: int = Query(default=50, ge=1, le=200),
     status_filter: str | None = Query(default=None),
+    defense_submission_id: UUID | None = Query(default=None),
+    attack_submission_id: UUID | None = Query(default=None),
 ) -> AdminEvaluationLogsResponse:
     """Return recent evaluation runs for the admin logs view."""
     rows = (
@@ -470,11 +818,18 @@ def get_recent_evaluations(
                     updated_at
                 FROM evaluation_runs
                 WHERE (:status_filter IS NULL OR status = :status_filter)
+                  AND (:defense_submission_id IS NULL OR defense_submission_id = :defense_submission_id)
+                  AND (:attack_submission_id IS NULL OR attack_submission_id = :attack_submission_id)
                 ORDER BY created_at DESC
                 LIMIT :limit
                 """
             ),
-            {"status_filter": status_filter, "limit": limit},
+            {
+                "status_filter": status_filter,
+                "defense_submission_id": str(defense_submission_id) if defense_submission_id else None,
+                "attack_submission_id": str(attack_submission_id) if attack_submission_id else None,
+                "limit": limit,
+            },
         )
         .mappings()
         .all()
@@ -524,6 +879,322 @@ def get_active_sessions(
     return AdminActiveSessionsResponse(count=len(items), items=items)
 
 
+def _build_worker_records(
+    *,
+    db: Session,
+    stale_after_seconds: int,
+) -> list[dict]:
+    registry = WorkerRegistry()
+    worker_ids = registry.get_all_active_workers()
+    if not worker_ids:
+        return []
+
+    metadata_map = {worker_id: registry.get_worker_metadata(worker_id) for worker_id in worker_ids}
+
+    job_ids = [meta.get("job_id") for meta in metadata_map.values() if meta.get("job_id")]
+    defense_ids = [
+        meta.get("defense_submission_id")
+        for meta in metadata_map.values()
+        if meta.get("defense_submission_id")
+    ]
+
+    job_map: dict[str, dict] = {}
+    if job_ids:
+        job_rows = (
+            db.execute(
+                text(
+                    """
+                    SELECT id, status, job_type
+                    FROM jobs
+                    WHERE id::text = ANY(:job_ids)
+                    """
+                ),
+                {"job_ids": job_ids},
+            )
+            .mappings()
+            .all()
+        )
+        job_map = {str(row["id"]): row for row in job_rows}
+
+    submission_map: dict[str, dict] = {}
+    if defense_ids:
+        submission_rows = (
+            db.execute(
+                text(
+                    """
+                    SELECT id, status, is_functional
+                    FROM submissions
+                    WHERE id::text = ANY(:submission_ids)
+                    """
+                ),
+                {"submission_ids": defense_ids},
+            )
+            .mappings()
+            .all()
+        )
+        submission_map = {str(row["id"]): row for row in submission_rows}
+
+    now_ts = datetime.now(timezone.utc).timestamp()
+    items = []
+    for worker_id in worker_ids:
+        meta = metadata_map.get(worker_id, {})
+        defense_id = meta.get("defense_submission_id")
+        job_id = meta.get("job_id")
+        queue_state = meta.get("queue_state")
+        started_at = _epoch_to_datetime(meta.get("started_at"))
+        last_heartbeat_at = _epoch_to_datetime(meta.get("heartbeat"))
+
+        heartbeat_age = None
+        if last_heartbeat_at is not None:
+            heartbeat_age = int(max(now_ts - last_heartbeat_at.timestamp(), 0))
+        is_stale = heartbeat_age is not None and heartbeat_age > stale_after_seconds
+
+        queued_attacks = None
+        try:
+            queued_attacks = registry.client.llen(f"worker:{worker_id}:attacks")
+        except Exception:
+            queued_attacks = None
+
+        job_row = job_map.get(str(job_id)) if job_id else None
+        submission_row = submission_map.get(str(defense_id)) if defense_id else None
+
+        submission_status = submission_row.get("status") if submission_row else None
+        submission_is_functional = submission_row.get("is_functional") if submission_row else None
+        job_status = job_row.get("status") if job_row else None
+        job_type = job_row.get("job_type") if job_row else None
+
+        task = _derive_worker_task(
+            submission_status=submission_status,
+            is_functional=submission_is_functional,
+            queue_state=queue_state,
+            job_status=job_status,
+        )
+
+        items.append(
+            {
+                "worker_id": worker_id,
+                "defense_submission_id": defense_id,
+                "job_id": job_id,
+                "job_status": job_status,
+                "job_type": job_type,
+                "submission_status": submission_status,
+                "submission_is_functional": submission_is_functional,
+                "queue_state": queue_state,
+                "started_at": started_at,
+                "last_heartbeat_at": last_heartbeat_at,
+                "heartbeat_age_seconds": heartbeat_age,
+                "is_stale": is_stale,
+                "queued_attacks": queued_attacks,
+                "task": task,
+            }
+        )
+
+    min_dt = datetime.min.replace(tzinfo=timezone.utc)
+    items.sort(
+        key=lambda item: item.get("last_heartbeat_at") or min_dt,
+        reverse=True,
+    )
+    return items
+
+
+@router.get("/workers", response_model=AdminWorkersResponse)
+def get_workers(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    stale_after_seconds: int = Query(default=120, ge=10, le=3600),
+) -> AdminWorkersResponse:
+    """Return active Redis-registered workers and their current status."""
+    items = _build_worker_records(db=db, stale_after_seconds=stale_after_seconds)
+    return AdminWorkersResponse(count=len(items), items=items)
+
+
+@router.get("/workers/{worker_id}", response_model=AdminWorkerRecord)
+def get_worker(
+    worker_id: str,
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    stale_after_seconds: int = Query(default=120, ge=10, le=3600),
+) -> AdminWorkerRecord:
+    """Return a single worker record by ID."""
+    items = _build_worker_records(db=db, stale_after_seconds=stale_after_seconds)
+    for item in items:
+        if item.get("worker_id") == worker_id:
+            return AdminWorkerRecord(**item)
+    raise HTTPException(status_code=404, detail="Worker not found")
+
+
+@router.get("/logs/workers", response_model=AdminWorkersResponse)
+def get_worker_logs(
+    _: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+    stale_after_seconds: int = Query(default=120, ge=10, le=3600),
+) -> AdminWorkersResponse:
+    """Return current worker status for the logs view."""
+    items = _build_worker_records(db=db, stale_after_seconds=stale_after_seconds)
+    return AdminWorkersResponse(count=len(items), items=items)
+
+
+@router.get("/assets", response_model=AdminAssetsResponse)
+def list_admin_assets(
+    _: AuthenticatedUser = Depends(require_admin_user),
+) -> AdminAssetsResponse:
+    """List current admin-managed assets."""
+    items = []
+    for asset_type in ("attack_template", "defense_validation_set"):
+        try:
+            stat = stat_admin_asset(asset_type)
+        except S3Error as exc:
+            if _is_missing_minio_object(exc):
+                continue
+            raise HTTPException(status_code=502, detail="Failed to fetch asset metadata") from exc
+
+        metadata = stat.get("metadata", {}) or {}
+        uploaded_at = stat.get("uploaded_at")
+        items.append(
+            AdminAssetRecord(
+                asset_type=asset_type,
+                object_key=stat["object_key"],
+                sha256=metadata.get("sha256") or "",
+                size_bytes=stat["size_bytes"],
+                original_filename=metadata.get("original_filename"),
+                uploaded_at=uploaded_at or datetime.now(timezone.utc),
+                uploaded_by=_metadata_uuid(metadata.get("uploaded_by")),
+                uploaded_by_email=metadata.get("uploaded_by_email"),
+                uploaded_by_username=metadata.get("uploaded_by_username"),
+            )
+        )
+
+    items.sort(key=lambda item: item.uploaded_at, reverse=True)
+    return AdminAssetsResponse(count=len(items), items=items)
+
+
+@router.get("/assets/{asset_type}", response_model=AdminAssetRecord)
+def get_admin_asset(
+    asset_type: str,
+    _: AuthenticatedUser = Depends(require_admin_user),
+) -> AdminAssetRecord:
+    """Get the current asset metadata for a given asset type."""
+    normalized = _normalize_asset_type(asset_type)
+    try:
+        stat = stat_admin_asset(normalized)
+    except S3Error as exc:
+        if _is_missing_minio_object(exc):
+            raise HTTPException(status_code=404, detail="Asset not found") from exc
+        raise HTTPException(status_code=502, detail="Failed to fetch asset metadata") from exc
+
+    metadata = stat.get("metadata", {}) or {}
+    uploaded_at = stat.get("uploaded_at") or datetime.now(timezone.utc)
+    return AdminAssetRecord(
+        asset_type=normalized,
+        object_key=stat["object_key"],
+        sha256=metadata.get("sha256") or "",
+        size_bytes=stat["size_bytes"],
+        original_filename=metadata.get("original_filename"),
+        uploaded_at=uploaded_at,
+        uploaded_by=_metadata_uuid(metadata.get("uploaded_by")),
+        uploaded_by_email=metadata.get("uploaded_by_email"),
+        uploaded_by_username=metadata.get("uploaded_by_username"),
+    )
+
+
+@router.post("/assets/{asset_type}", response_model=AdminAssetRecord)
+async def upload_admin_asset_file(
+    asset_type: str,
+    request: Request,
+    file: UploadFile = File(...),
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminAssetRecord:
+    """Upload or replace an admin-managed asset (attack template/defense validation set)."""
+    event_type = "admin.asset.update"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
+
+        normalized = _normalize_asset_type(asset_type)
+        if not file.filename or not file.filename.endswith(".zip"):
+            raise HTTPException(status_code=400, detail="Asset must be a ZIP archive")
+
+        settings = get_settings()
+        validate_file_size(file, max_mb=settings.max_file_size_mb)
+
+        content = await file.read()
+        if not content:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+        uploaded_at = datetime.now(timezone.utc)
+        upload_result = upload_admin_asset(
+            content,
+            asset_type=normalized,
+            metadata={
+                "sha256": None,
+                "original_filename": file.filename,
+                "uploaded_by": str(current_user.user_id),
+                "uploaded_by_email": current_user.email,
+                "uploaded_by_username": current_user.username,
+                "uploaded_at": uploaded_at.isoformat(),
+            },
+        )
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
+
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "asset_type": normalized,
+                "object_key": upload_result["object_key"],
+                "sha256": upload_result["sha256"],
+                "size_bytes": upload_result["size_bytes"],
+            },
+        )
+
+        return AdminAssetRecord(
+            asset_type=normalized,
+            object_key=upload_result["object_key"],
+            sha256=upload_result["sha256"],
+            size_bytes=upload_result["size_bytes"],
+            original_filename=file.filename,
+            uploaded_at=uploaded_at,
+            uploaded_by=current_user.user_id,
+            uploaded_by_email=current_user.email,
+            uploaded_by_username=current_user.username,
+        )
+    except HTTPException as exc:
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            metadata={"asset_type": asset_type},
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            metadata={"asset_type": asset_type},
+        )
+        raise
+
+
 @router.get("/logs/audit", response_model=AdminAuditLogsResponse)
 def get_audit_logs(
     _: AuthenticatedUser = Depends(require_admin_user),
@@ -531,6 +1202,7 @@ def get_audit_logs(
     limit: int = Query(default=50, ge=1, le=200),
     event_type: str | None = Query(default=None),
     success: bool | None = Query(default=None),
+    user_id: UUID | None = Query(default=None),
 ) -> AdminAuditLogsResponse:
     """Return recent audit log entries."""
     rows = (
@@ -551,6 +1223,7 @@ def get_audit_logs(
                 FROM audit_logs
                 WHERE (:event_type IS NULL OR event_type = :event_type)
                   AND (:success IS NULL OR success = :success)
+                  AND (:user_id IS NULL OR user_id = :user_id)
                 ORDER BY created_at DESC
                 LIMIT :limit
                 """
@@ -558,6 +1231,7 @@ def get_audit_logs(
             {
                 "event_type": event_type,
                 "success": success,
+                "user_id": str(user_id) if user_id else None,
                 "limit": limit,
             },
         )
@@ -935,6 +1609,163 @@ def revoke_user_sessions(
         return AdminRevokeSessionsResponse(user_id=user_row["id"], revoked_count=revoked)
     except HTTPException as exc:
         # Avoid rolling back on HTTP errors so the session stays usable in tests.
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc.detail),
+            target_user_id=user_id,
+        )
+        raise
+    except Exception as exc:
+        db.rollback()
+        _log_admin_action_failure(
+            request=request,
+            current_user=current_user,
+            event_type=event_type,
+            message=str(exc),
+            target_user_id=user_id,
+        )
+        raise
+
+
+@router.delete("/users/{user_id}", response_model=AdminUserDeleteResponse)
+def delete_user(
+    user_id: UUID,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> AdminUserDeleteResponse:
+    """Delete a user account and cascade-delete related records."""
+    event_type = "admin.user.delete"
+    try:
+        require_admin_origin(request, require_present=True)
+        action_token = require_admin_action_token(
+            request,
+            db=db,
+            session_id=str(current_user.session_id),
+        )
+
+        if user_id == current_user.user_id:
+            raise HTTPException(status_code=400, detail="Cannot delete your own account")
+
+        submission_count = (
+            db.execute(
+                text(
+                    """
+                    SELECT COUNT(*)
+                    FROM submissions
+                    WHERE user_id = :user_id
+                    """
+                ),
+                {"user_id": str(user_id)},
+            ).scalar()
+            or 0
+        )
+
+        object_keys: set[str] = set()
+        defense_keys = db.execute(
+            text(
+                """
+                SELECT dsd.object_key
+                FROM defense_submission_details dsd
+                JOIN submissions s
+                  ON s.id = dsd.submission_id
+                WHERE s.user_id = :user_id
+                  AND dsd.object_key IS NOT NULL
+                """
+            ),
+            {"user_id": str(user_id)},
+        ).scalars().all()
+        object_keys.update([key for key in defense_keys if key])
+
+        attack_zip_keys = db.execute(
+            text(
+                """
+                SELECT asd.zip_object_key
+                FROM attack_submission_details asd
+                JOIN submissions s
+                  ON s.id = asd.submission_id
+                WHERE s.user_id = :user_id
+                """
+            ),
+            {"user_id": str(user_id)},
+        ).scalars().all()
+        object_keys.update([key for key in attack_zip_keys if key])
+
+        attack_file_keys = db.execute(
+            text(
+                """
+                SELECT af.object_key
+                FROM attack_files af
+                JOIN submissions s
+                  ON s.id = af.attack_submission_id
+                WHERE s.user_id = :user_id
+                  AND af.object_key IS NOT NULL
+                """
+            ),
+            {"user_id": str(user_id)},
+        ).scalars().all()
+        object_keys.update([key for key in attack_file_keys if key])
+
+        row = (
+            db.execute(
+                text(
+                    """
+                    DELETE FROM users
+                    WHERE id = :user_id
+                    RETURNING id, email, username
+                    """
+                ),
+                {"user_id": str(user_id)},
+            )
+            .mappings()
+            .fetchone()
+        )
+
+        if row is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        consume_admin_action_token(
+            db,
+            session_id=str(current_user.session_id),
+            token=action_token,
+        )
+        db.commit()
+
+        deleted_objects = 0
+        for key in object_keys:
+            try:
+                delete_object(key)
+                deleted_objects += 1
+            except Exception:
+                # Best-effort cleanup; don't fail deletion if object removal fails.
+                pass
+
+        client_ip, user_agent = _request_meta(request)
+        log_audit_event(
+            event_type=event_type,
+            user_id=current_user.user_id,
+            email=current_user.email,
+            ip_address=client_ip,
+            user_agent=user_agent,
+            success=True,
+            metadata={
+                "target_user_id": str(row["id"]),
+                "target_email": row["email"],
+                "submission_count": submission_count,
+                "deleted_objects": deleted_objects,
+            },
+        )
+
+        return AdminUserDeleteResponse(
+            user_id=row["id"],
+            email=row["email"],
+            username=row["username"],
+            deleted_submissions=submission_count,
+            deleted_objects=deleted_objects,
+        )
+    except HTTPException as exc:
         _log_admin_action_failure(
             request=request,
             current_user=current_user,

--- a/services/api/schemas/admin.py
+++ b/services/api/schemas/admin.py
@@ -139,3 +139,128 @@ class AdminUserActionResponse(BaseModel):
 class AdminRevokeSessionsResponse(BaseModel):
     user_id: UUID
     revoked_count: int
+
+
+class AdminUserDeleteResponse(BaseModel):
+    user_id: UUID
+    email: str
+    username: str
+    deleted_submissions: int
+    deleted_objects: int
+
+
+class AdminSubmissionRecord(BaseModel):
+    submission_id: UUID
+    user_id: UUID
+    username: str
+    email: str
+    submission_type: str
+    status: str
+    version: str
+    display_name: str | None = None
+    is_functional: bool | None = None
+    functional_error: str | None = None
+    created_at: datetime
+    deleted_at: datetime | None = None
+
+
+class AdminUserSubmissionsResponse(BaseModel):
+    count: int
+    items: list[AdminSubmissionRecord]
+
+
+class AdminSubmissionLogRecord(BaseModel):
+    submission_id: UUID
+    user_id: UUID
+    username: str
+    email: str
+    submission_type: str
+    status: str
+    version: str
+    display_name: str | None = None
+    functional_error: str | None = None
+    created_at: datetime
+
+
+class AdminSubmissionLogsResponse(BaseModel):
+    count: int
+    items: list[AdminSubmissionLogRecord]
+
+
+class AdminDefenseEvaluationRecord(BaseModel):
+    attack_submission_id: UUID
+    attack_user_id: UUID
+    attack_username: str
+    attack_email: str
+    attack_status: str
+    attack_version: str
+    attack_display_name: str | None = None
+    attack_created_at: datetime
+    evaluation_status: str
+    evaluation_run_id: UUID | None = None
+    evaluation_updated_at: datetime | None = None
+    evaluation_error: str | None = None
+
+
+class AdminDefenseEvaluationsResponse(BaseModel):
+    count: int
+    items: list[AdminDefenseEvaluationRecord]
+
+
+class AdminAttackEvaluationRecord(BaseModel):
+    defense_submission_id: UUID
+    defense_user_id: UUID
+    defense_username: str
+    defense_email: str
+    defense_status: str
+    defense_version: str
+    defense_display_name: str | None = None
+    defense_created_at: datetime
+    evaluation_status: str
+    evaluation_run_id: UUID | None = None
+    evaluation_updated_at: datetime | None = None
+    evaluation_error: str | None = None
+
+
+class AdminAttackEvaluationsResponse(BaseModel):
+    count: int
+    items: list[AdminAttackEvaluationRecord]
+
+
+class AdminWorkerRecord(BaseModel):
+    worker_id: str
+    defense_submission_id: UUID | None = None
+    job_id: UUID | None = None
+    job_status: str | None = None
+    job_type: str | None = None
+    submission_status: str | None = None
+    submission_is_functional: bool | None = None
+    queue_state: str | None = None
+    started_at: datetime | None = None
+    last_heartbeat_at: datetime | None = None
+    heartbeat_age_seconds: int | None = None
+    is_stale: bool
+    queued_attacks: int | None = None
+    task: str | None = None
+
+
+class AdminWorkersResponse(BaseModel):
+    count: int
+    items: list[AdminWorkerRecord]
+
+
+class AdminAssetRecord(BaseModel):
+    asset_type: str
+    object_key: str
+    sha256: str
+    size_bytes: int
+    original_filename: str | None = None
+    uploaded_at: datetime
+    uploaded_by: UUID | None = None
+    uploaded_by_email: str | None = None
+    uploaded_by_username: str | None = None
+
+
+class AdminAssetsResponse(BaseModel):
+    count: int
+    items: list[AdminAssetRecord]

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -139,6 +139,9 @@ def fake_redis():
             self.lists[key].extend(str(v) for v in values)
             return len(self.lists[key])
 
+        def llen(self, key):
+            return len(self.lists.get(key, []))
+
         def setnx(self, key, value):
             if key in self.data:
                 return False


### PR DESCRIPTION
Lots of routes that are necessary for all the functionality that you want for the admin page. I'm kind of tired right now so I'm submitting this and going to bed. I didn't really test or review this much, but I'm pretty sure this would work for all that we need. Here's a dump of all the routes we have currently. [I wouldn't merge this yet]

'GET /admin/overview'
Dashboard summary counts for users, sessions, submissions, eval runs, and jobs.
'GET /admin/users'
Lists users with last seen + active sessions. Supports search, include_disabled, sorting, and paging.
'GET /admin/users/{user_id}/submissions'
Lists submissions for a single user. Supports submission_type and include_deleted.
'POST /admin/actions/token'
Issues a short-lived one-time admin action token for write operations.

User Management Actions

'POST /admin/users/{user_id}/disable'
Sets disabled_at, logs audit.
'POST /admin/users/{user_id}/enable'
Clears disabled_at, logs audit.
'POST /admin/users/{user_id}/admin'
Promote/demote admin based on body { is_admin: true|false }.
'POST /admin/users/{user_id}/sessions/revoke'
Revokes all active sessions for the user.
'DELETE /admin/users/{user_id}'
Deletes the user (cascade), attempts MinIO cleanup, logs audit.

Competition Control

'GET /admin/submissions/status'
Returns manual close flag, scheduled close time, and computed “is_closed”.
'POST /admin/submissions/close'
Manually closes submissions (until reopened).
'POST /admin/submissions/open'
Reopens submissions.
'POST /admin/submissions/schedule'
Sets or clears scheduled close datetime.

Evaluation Coverage

'GET /admin/submissions/defense/{defense_id}/attacks'
Lists attacks and their latest evaluation status against the defense.
'GET /admin/submissions/attack/{attack_id}/defenses'
Lists defenses and their latest evaluation status against the attack.

Logs

'GET /admin/logs/audit'
Audit events. Filters by event_type, success, user_id, email, limit.
'GET /admin/logs/submissions'
Submission events. Filters by submission_type, status_filter, user_id, search, limit.
'GET /admin/logs/evaluations'
Evaluation runs. Filters by status_filter, defense_submission_id, attack_submission_id, limit.
'GET /admin/logs/jobs'
Job records. Filters by status_filter, user_id, limit.

Sessions

'GET /admin/sessions/active'
Lists active (non-revoked, non-expired) sessions.

Workers

'GET /admin/workers'
Live worker list from Redis + DB joins. Supports stale_after_seconds.
'GET /admin/workers/{worker_id}'
Detail for a specific worker ID.
'GET /admin/logs/workers'
Same as workers list, intended for log view.

Assets

'GET /admin/assets'
Lists current attack template / defense validation set metadata.
'GET /admin/assets/{asset_type}'
Metadata for a specific asset type.
'POST /admin/assets/{asset_type}'
Upload/replace asset ZIP; writes fixed MinIO key + metadata; audit logged.